### PR TITLE
Redesign: route to the work, rebuild the reading list

### DIFF
--- a/.planning/research/minimal-personal-site-patterns.md
+++ b/.planning/research/minimal-personal-site-patterns.md
@@ -1,0 +1,253 @@
+# Minimal Personal Sites for Senior Technical People
+
+**Project:** italovietro.com — homepage and section structure
+**Researched:** 2026-08-05
+**Method:** Every site below was fetched directly (`curl` for HTML + linked CSS) and read as source. No blog posts, listicles, or design commentary were used. Where a claim depends on a colour value, font stack, or nav item, it comes from that site's own markup or stylesheet.
+**Confidence:** HIGH on structure, typography, and colour (read from source). MEDIUM on intent (inferred from the sites' own wording, which is quoted wherever it carries the claim).
+
+---
+
+## Sample
+
+15 sites attempted, **14 with primary-source data**.
+
+| # | Site | Fetched | Notes |
+|---|------|---------|-------|
+| 1 | https://yegge.ai/ | yes | HTML + `style.css` (38 KB) |
+| 2 | https://macwright.com/ | yes | single inline `<style>`, no external CSS |
+| 3 | https://danluu.com/ | yes | 5-rule inline `<style>`, no external CSS |
+| 4 | https://simonwillison.net/ | yes | HTML + `all.7977d7c44aeb.css` |
+| 5 | https://jvns.ca/ | yes | HTML + `screen.css` |
+| 6 | https://gwern.net/ | yes | HTML + `head.css` + `style.css` (50 KB) |
+| 7 | https://patrickcollison.com/ | yes | HTML (1.4 KB) + `style.css` (583 B) |
+| 8 | https://tomcritchlow.com/ | yes | HTML + `all.css` + Tachyons |
+| 9 | https://maggieappleton.com/ | yes | HTML + two Astro CSS bundles |
+| 10 | https://brandur.org/ | yes | HTML + Tailwind + `tailwind_custom.css` |
+| 11 | https://apenwarr.ca/ | yes | HTML + `apenwarr.css` (284 B) |
+| 12 | https://lethain.com/ | yes | added — closest professional analogue (eng leader, books, talks) |
+| 13 | https://thorstenball.com/ | yes | added — has Books + Talks + Podcasts as separate sections |
+| 14 | https://ciechanow.ski/ | yes | added — homepage is a single long article |
+| — | https://rachelbythebay.com/ | **no** | Unreachable from three separate egress paths: `curl` over IPv4 and IPv6 timed out at 45 s on `/` and `/w/`; `WebFetch` returned `ECONNREFUSED 216.218.228.215:443`; a reader proxy returned 403. She is known to block automated fetchers. **Excluded from all counts** rather than described from memory. |
+
+`lethain.com`, `thorstenball.com`, and `ciechanow.ski` were added because they cover cases the original list did not: an engineering leader with books and a speaking history (Larson), a site with `Talks`, `Podcasts`, and `Books` as distinct dated sections (Ball), and a site whose homepage is a single article that has not changed in 20 months (Ciechanowski). All three are directly relevant to the archived-writing and speaking questions.
+
+**All counts below are out of 14.**
+
+---
+
+## Table 1 — What the homepage does, and how you navigate
+
+| Site | First screen, specifically | Primary job | Top-level nav items | Nav names | Portrait? |
+|---|---|---|---|---|---|
+| yegge.ai | 375×500 portrait captioned "Photographed 2025", beside a client pull-quote with an SVG ornament | identity | 6 | About · Services · Atlas · Friends · Search · Get in touch | **yes** — large, first screen |
+| macwright.com | Name, 7-link list, 3-button theme toggle, then `Writing ⇢` with 10 dated items | contents | 7 | Writing · Reading · Photos · Projects · Drawings · Micro · About | no |
+| danluu.com | A `<ul>` of 197 posts, each prefixed `mm/yy`. No name, no nav, **no `<title>` tag** | feed | 0 (6 text links in footer) | — | no |
+| simonwillison.net | Tag cloud with counts (`generative-ai 1,918`), search box, sponsor line, then full-text entries | feed | 4 | About · Subscribe · TILs · Tools (+ 6 type tabs) | no |
+| jvns.ca | Orange nav bar; "Hey! I'm Julia… Here's every post I've ever written, organized by category"; 10 newest; then the whole archive | feed | 6 (+4 secondary) | About · Talks · Projects · Mastodon · Bluesky · Github (+ Favorites · TIL · Zines · RSS) | no |
+| gwern.net | JS warning, 7-link bar, then a ~45-entry topic directory, then "This is the website of Gwern Branwen. I write about AI, psychology, & statistics." | contents | 7 | Site · Me · New · Blog · Links · Patreon · Substack | no |
+| patrickcollison.com | Name and 15 links, right-aligned. **`<div id="content">` is empty.** | contents | **15** | About · Advice · Bookshelf · Culture · Dispatches · Fast · Growth · Labs · Links · Pollution · Progress · Questions · Solar · SV history · Travel | no |
+| tomcritchlow.com | Fixed left sidebar with icons; 3-paragraph bio; then `Latest Writing` (10 dated); then 4 project cards | identity | 6 (+2 Projects, +3 Elsewhere) | Home · About me · Writing · Library · Newsletter · Search | no |
+| maggieappleton.com | 10–12 item menu **with a description per item**; 2-line bio; then per-section digests with relative ages | contents | 10–12 | The Garden · Essays · Notes · Patterns · Smidgeons · Talks · Podcasts · Library · Antilibrary · Now · About | no |
+| brandur.org | 8-link bar + 3-state theme toggle; one routing paragraph; full-bleed photograph; 3 items with type badges | contents | 8 | Articles · Atoms · Fragments · Newsletter · Sequences · Now · Uses · About | no |
+| apenwarr.ca | `/` **302-redirects to the newest post.** Blue textured wordmark image (372×63), Comic Sans tagline "Pithy. / Like an orange", disclaimer, then the post | feed | 0 | — | no (the image is a **wordmark**, not a face) |
+| lethain.com | Site title "Irrational Exuberance", 5 links, 2-sentence bio, then a long dated feed with ⭐ markers | feed | 5 | Popular · Tags · Newsletter · RSS · About | no |
+| thorstenball.com | Left sidebar of 8 items; square avatar; "Hello! I'm Thorsten." + 4 short paragraphs | identity | 8 | About · Books · Blog · Podcasts · Talks · Register Spill · Misc · Contact | **yes** — avatar, top of column |
+| ciechanow.ski | Name + 7 links, then the full **December 17, 2024** article ("Moon"), unchanged | feed | 7 | Blog · Archives · Patreon · X/Twitter · Instagram · e-mail · RSS | no |
+
+### Counts from Table 1
+
+- **The sample disagrees on the homepage's job.** Feed-first **6/14** (danluu, simonwillison, jvns, apenwarr, lethain, ciechanow). Contents-first **5/14** (macwright, gwern, patrickcollison, maggieappleton, brandur). Identity-first **3/14** (yegge, tomcritchlow, thorstenball). There is no majority and no basis for claiming one is standard.
+- **First-person prose about the person appears on 9/14 homepages.** Absent on 5 (macwright, danluu, simonwillison, patrickcollison, ciechanow). Where present it is short: the longest is tomcritchlow at 3 paragraphs, then yegge at 3, thorstenball at 4 short ones. **No site in the sample runs essay-length biography on the homepage.**
+- **Nav size: of the 12 sites with a nav, 10 have 4–8 items** (4, 5, 6, 6, 6, 7, 7, 7, 8, 8; median **7**). Only two exceed 8: maggieappleton (10–12) and patrickcollison (15). Two sites have no nav at all (danluu, apenwarr).
+- **A portrait appears on 2/14 homepages** — yegge.ai and thorstenball.com. Both are people with something to sell (advisory engagements; self-published books). The other 12, including every pure-writing site, show no face.
+- **2/14 homepages are literally the newest post** (apenwarr via a 302 redirect; ciechanow serving a 20-month-old article at `/`).
+- **1/14 has an empty content area** — patrickcollison.com ships `<div id="content"></div>`. The homepage is nothing but a name and 15 links.
+
+---
+
+## Table 2 — Typography, colour, and what the accent is for
+
+| Site | Body type | Heading type | Webfont? | Distinct colours | Accent | Accent's jobs |
+|---|---|---|---|---|---|---|
+| yegge.ai | serif — Crimson Pro | serif — Cormorant Garamond | **yes**, Google, 4 families | 3 hues / 11 tokens, warm cream + warm near-black | **oxblood** `#6b1d1d` light, `#d97070` dark | links, the `.ai` in the wordmark, active nav item, CTA button, `::selection`, focus outline, card hover border, badges — **7 jobs** |
+| macwright.com | sans — system stack | sans — same | no | 2 (bg/text) + 1 blue | **none for links**: `--link: var(--text)` | Blue is confined to the `/micro` section only. Links elsewhere are body-coloured and underlined. |
+| danluu.com | browser default (serif) | n/a | no | **0 declared** | none | Nothing. The CSS is 5 layout rules; `<meta name=color-scheme content="light dark">` is the entire theming. |
+| simonwillison.net | sans — Helvetica Neue | sans; georgia for quotes | no | **38 `--color-*` tokens** | blue `#0303bb` / `#7eb8ff` dark; purple `#636` visited | links, a *separate* link-underline colour, visited links, and a different colour per content type (release = purple, TIL = green) |
+| jvns.ca | serif — PT Serif | sans — Montserrat | **yes**, 4 families | ~8 | **orange family**: `#FF7E3E` nav, `#FF5E00` h1, `#CC4B00` links | nav bar background, h1, links, a 35 px striped border-image frame, triangular corner cuts, favourite stars |
+| gwern.net | serif — Source Serif 4 | serif + decorative initials | **yes**, self-hosted, **175 `@font-face`** | many, named (`--GW-blood-red`, `--GW-holly-leaf-green`) | red / green, seasonal variants | links, visited links, hover — with named seasonal palettes |
+| patrickcollison.com | sans — Helvetica 13px | sans — Myriad Pro | no | **5** (`#333` `#0864c7` `#aaa` `#777` `#eee`) | blue `#0864c7` | **links only** |
+| tomcritchlow.com | sans — Libre Franklin | sans | **yes**, Google, 3 families | ~6 | **green** `#02AD28` + `#00ff00` | prose links, uppercase section labels, borders, a highlighter-pen hover (`box-shadow: inset 0 -24px 0 rgba(0,255,0,.4)`), dotted arrows, a bullet dot. **Post titles in the homepage list are black, not green.** |
+| maggieappleton.com | serif — Canela Text | serif — Canela Deck + Lato | **yes**, self-hosted, 6 files | **15 named colours × 2 themes** (crimson, salmon, sea-blue, gold, purple, three creams…) | a palette, not an accent | illustration, tags, links |
+| brandur.org | sans — `ui-sans-serif` | sans; serif for deks | no | cream `#f6f5e9` + slate scale | **none** | Links get `border-b` + bold sans + no underline. No colour on links at all. |
+| apenwarr.ca | serif — et-book/Palatino (named, not loaded) | browser default | no | 5 | blue `#0000cc` | the Comic Sans tagline, `.related` links (`#44f`); **green** marks the current nav item |
+| lethain.com | sans — system stack (Tachyons) | sans | no | ~4 | **none for titles** | Post titles are black. ⭐ marks featured posts. |
+| thorstenball.com | sans — Inter, self-hosted, preloaded | sans — Inter | **yes**, 6 woff2 | 5 | gold | link/hover accent |
+| ciechanow.ski | sans — Inter | sans — IBM Plex Sans | **yes**, Google, 2 families | ~8 | blue `#0181eb`, gold `#CA9839` | links |
+
+### Counts from Table 2
+
+- **Sans body type 8/14** (macwright, simonwillison, patrickcollison, tomcritchlow, brandur, lethain, thorstenball, ciechanow). **Serif body 5/14** (yegge, jvns, gwern, maggieappleton, apenwarr). **No font declared at all: 1** (danluu).
+- **Webfonts split exactly 7/7.** Loaded: yegge, jvns, gwern, tomcritchlow, maggieappleton, thorstenball, ciechanow. System stack only: macwright, danluu, simonwillison, patrickcollison, brandur, apenwarr, lethain. **This is the sample's sharpest internal disagreement** — there is no defensible "minimal sites use system fonts" claim.
+- **One accent hue, used on links: 7/14** (yegge, patrickcollison, tomcritchlow, jvns, thorstenball, ciechanow, apenwarr).
+- **No colour on links at all: 4/14** (macwright, danluu, brandur, lethain). All four are heavily-read writing sites. Brandur substitutes a bottom border + bold sans; macwright substitutes an underline and *reserves* colour for one section; lethain and danluu just use black.
+- **Multiple accent hues: 3/14** (simonwillison 38 tokens, gwern seasonal named palettes, maggieappleton 15 named colours).
+- **Accent used for links only (nothing else): 3/14** — patrickcollison, thorstenball, ciechanow. Where a site has one accent doing *many* jobs, the count is high: yegge 7 jobs, jvns 5, tomcritchlow 5.
+- **Explicit light+dark support: 6/14** (yegge — dark by default via `data-theme`; macwright — `light-dark()` + `color-scheme` + a 3-button toggle; simonwillison — `prefers-color-scheme` + `[data-theme]`; brandur — 3-state radio toggle with `localStorage`; maggieappleton — every colour token has a dark twin; gwern — a `mode-selector` widget). `danluu` declares `color-scheme: light dark` and nothing else. **8/14 are light-only**, including jvns, patrickcollison, tomcritchlow, apenwarr, lethain, thorstenball, ciechanow.
+- **Of the 6 with real dark modes, 4 lift the accent rather than reuse it**: yegge `#6b1d1d → #d97070`, simonwillison `#0303bb → #7eb8ff`, maggieappleton crimson `#5f023e → #e85aab`, macwright blue `blue → #b5b5ff`. Two sites (yegge, maggieappleton) leave dated CSS comments about re-tuning for WCAG AA in dark.
+
+---
+
+## Table 3 — Personality, omissions, and dormant content
+
+| Site | Personality carried by | Deliberately omitted | Dormant / archival content |
+|---|---|---|---|
+| yegge.ai | all-serif Garamond setting; oxblood; a drop cap; a `¶` closing mark; an abstract SVG ornament ("Ghost Track" `lp-mark.svg`) used twice — as a quote rule and a footer mark; portrait; wordmark with an accented `.ai` | dates on the homepage; social icons; comments | **Best-in-sample.** `/talks.html` owns the gaps in prose: *"Most of my talks were never recorded, or the recordings have been lost. But I've managed to find a few of them."* `/atlas.html` grades 150+ old essays with a legend: **★ Essentials · 👍 Good read · 💩 Not worth it · 🔮 Called it · 🤡 Whiffed it** — old work is kept and rated, including "not worth it". Cross-links: *"Long-form podcast conversations live on the Podcasts page."* |
+| macwright.com | nothing decorative; personality is in the section names (Micro, Drawings) and the writing. Star ratings as inline SVG `<use>` on books | social icons (only `rel=me` in `<head>`); search; comments; bio | `/writing/` is one **flat list back to 2011** — no year headers, no pagination, no "archive" framing. Every item ISO-dated. Current nav item marked `⇠`. |
+| danluu.com | **nothing at all.** No title tag, no nav, no fonts, no colours | title tag; nav; header; fonts; colours; search; images; comments | Two tiers in one list: his own posts, then a `#pt` anchor row labelled "Patreon posts" with a placeholder date `xx/xx`. A 2017–2019 Patreon run is kept inline, dated `mm/yy`. |
+| simonwillison.net | content-type badges; source favicons on links; his own pelican illustrations | dark-only design; comments on the homepage | Tag counts (`security 620`) act as a durability signal. Type tabs (Entries · Links · Quotes · Notes · Guides · Elsewhere) let old material be filtered rather than hidden. |
+| jvns.ca | **colour** — orange nav bar, `noise.png` texture, a striped `border-image` frame, triangular corner cuts, `star.svg` between nav items. Loudest identity in the sample | dark mode; search; comments | `/talks/` opens with a hedge: *"Here's a mostly up to date list of all the talks I've given."* Newest talk 2023; years live inside the titles; no notice, no demotion. A `Favorites` nav item and an orange star surface durable posts. |
+| gwern.net | **typography as identity** — 175 `@font-face`, decorative drop-cap faces (Cheshire Initials, Goudy Initialen, Kanzlei Initialen), sidenotes, link popups; named seasonal colours | dates on the index; a photo | The homepage index is undated. Old and new sit together under topics; `New`/`changelog` is a separate nav item that carries recency instead. |
+| patrickcollison.com | **nothing.** Plain Helvetica 13px, right-aligned link list. Personality = the choice of 15 idiosyncratic topics (Fast, Pollution, Solar, SV history) | everything: images, dates, search, social, comments, even homepage content | **The most on-point precedent in the sample.** `/bookshelf` opens with a dated staleness notice: *"As of mid 2026, this page has not been updated in around 10 years. It is currently kept around for posterity, though I may remove it at some stage."* The page stays in nav, unchanged, undemoted. Books are flagged green (great) / light blue (above average). |
+| tomcritchlow.com | green + a highlighter-pen link hover + hand-drawn dotted arrows + the tagline "Move. Think. Create." | dark mode; comments | Homepage `Latest Writing` shows June 2026, then **August 2025** — an 11-month gap displayed with full dates and no comment. `/library` uses tabs (Music · Books · All Links) + tag filters. |
+| maggieappleton.com | **illustration** — a hand-drawn cover for every essay, talk, and book. She is an illustrator | dates (absolute); comments; social icons | **Relative ages on every item**: "3 months ago", "over 1 year ago". A count badge per section (`10` talks, `64` library books). Section descriptions in the nav itself. Hedged one-liner: *"I occassionally give talks."* A separate **Antilibrary** — "Books I like the idea of having read". |
+| brandur.org | a full-bleed photograph on the homepage; cream `#f6f5e9` paper; a serif drop-cap `::first-letter` on articles | link colour; social icons; comments; search | **Routes by cadence.** The homepage's only prose: *"The section updated most often is **atoms**… I update my **now page** monthly according to what I'm working on… I **publish a newsletter** as often as I can."* Footer note: *"These are a short selection of recently posted writing across all categories."* `/now` admits the lapse in the copy — *"It's been way too long since I updated this page. I knew it was a problem, so I set a monthly calendar reminder to update it, and … it didn't work."* — carries *"This page was last updated on Jul 25, 2026"*, and keeps prior versions stacked below by date. |
+| apenwarr.ca | **deliberate anti-design** — a Comic Sans tagline, a blue textured wordmark JPEG, a `chicken.gif` favicon, a 6-inch measure, an "I do not speak for your employer" disclaimer | nav; dark mode; comments; search | Actively **resurfaces** old posts: `Related` / `Unrelated` blocks pull items from 2006, 2012, 2019 **with the year in parentheses**. Old work is a feature, not a liability. |
+| lethain.com | nothing visual. The blog name "Irrational Exuberance" and ⭐ markers on featured posts | dark mode; images; social icons; comments | **Dates everything, including the About page** — `/about/` reads "Published on April 1, 2007." Body copy dates the archive explicitly: *"This blog, Irrational Exuberance, has been around since 2007."* Links out to *"some public speaking as well"* rather than giving speaking a nav slot. |
+| thorstenball.com | avatar + gold accent; otherwise the writing. Notable: ~30 lines of commented-out "What I value" prose left in the HTML | dark mode; search; comments; images | **Dormant and live sections sit as equal siblings.** `/talks`: newest **17 Nov 2024**, then a **7-year gap** back to 14 Sep 2017 — no label, no apology, dates do the work. `/podcasts`: 20 entries, newest **22 Jan 2026**, actively growing. Both are plain `date / venue / title (Slides)` lists. |
+| ciechanow.ski | the interactive WebGL diagrams inside the articles | dark mode; comments; search; a photo | **No signal at all.** A Dec 2024 article is served at `/` in Aug 2026, presented as current. `Archives` is a separate nav item. |
+
+### Counts from Table 3
+
+- **0/14 homepages carry a comment widget.** Every `comment` string found was a false positive (post titles; simonwillison's `/elsewhere/comment/` content type).
+- **0/14 homepage documents contain a consent banner or newsletter modal.**
+- **Search: 4/14** (yegge — nav item + Pagefind; simonwillison — a `<form action="/search/">` on the homepage; gwern; tomcritchlow — nav item). **10/14 omit it.**
+- **Iconised social rows: 1/14** — tomcritchlow, using Feather icons in a sidebar group literally labelled "Elsewhere". Everyone else either uses plain text links (danluu footer, jvns header, ciechanow nav, gwern nav) or folds them into prose (thorstenball: *"You can also find me on Twitter, Bluesky…"*; apenwarr: *"You can find me on Bluesky. Or subscribe with RSS."*). **7/14 have no social links on the homepage at all** (macwright, simonwillison, patrickcollison, maggieappleton, brandur, lethain, yegge).
+- **Dates on the homepage: 9/14 absolute** (macwright ISO, danluu `mm/yy`, simonwillison full, jvns `Jul 21 2026`, tomcritchlow full, brandur full, apenwarr ISO, lethain full, ciechanow full). **1/14 relative** (maggieappleton). **4/14 none** (yegge, gwern, patrickcollison, thorstenball).
+- **Every dated site shows the year.** No exceptions. The shortest format in the sample is danluu's `mm/yy` — which still carries the year in 5 characters.
+- **Nobody hides a dormant section. 0/14 removed it from nav, collapsed it, or moved it below the fold.** All 14 keep dormant material at the same level as live material.
+- **Explicit dated staleness notice: 2/14** — patrickcollison `/bookshelf`, brandur `/now`.
+- **Framing prose that owns the gap without a formal notice: 2/14** — yegge `/talks`, jvns `/talks`.
+- **Dates or relative ages do all the work, no notice: 8/14** — macwright, thorstenball, lethain, tomcritchlow, danluu, maggieappleton, apenwarr, simonwillison.
+- **No signal at all, stale content presented as current: 2/14** — ciechanow, gwern (undated index).
+- **A curation marker separating durable old work from the rest: 6/14** — yegge (emoji legend), lethain (⭐), jvns (Favorites + orange star), macwright (star ratings), patrickcollison (green / light-blue book flags), simonwillison (tag counts). **This is the single most common active response to an ageing archive.**
+- **Talks and podcasts are separate sections in 3/3 sites that have both** — thorstenball (`/talks`, `/podcasts`), yegge (`talks.html`, `podcasts.html`, cross-linked in prose), maggieappleton (`/talks`, `/podcasts`, each with a description). No site in the sample merges them.
+- **Reading lists use a rating or flag in 4/5 cases** — macwright (star SVGs), patrickcollison (colour flags), tomcritchlow (tags), maggieappleton (a curated Library plus a separate Antilibrary). Only maggieappleton and macwright also show a date per book.
+
+---
+
+## Where the sample contradicts itself
+
+Stated plainly, because these are the places where "best practice" claims would be manufactured:
+
+1. **Homepage job — no majority.** 6 feed-first, 5 contents-first, 3 identity-first. Anyone claiming minimal sites "should" route rather than feed is picking a faction.
+2. **Webfonts — an exact 7/7 tie.** gwern loads 175 `@font-face` declarations; danluu declares no font at all. Both are among the most-read technical writers alive.
+3. **Link colour — 7 use one accent, 4 use none, 3 use a palette.** The four with no link colour (macwright, danluu, brandur, lethain) are not the least designed sites; brandur's is among the most designed.
+4. **Nav size — 4 to 15 items.** patrickcollison's 15-item nav is the *entire* homepage; maggieappleton's 12 items each carry a one-line description. Both work; neither is minimal by count.
+5. **Dark mode — 6 of 14.** Half the sample, including several 2026-updated sites, ships light-only.
+6. **Portrait — 2 of 14,** and both belong to people selling something. If a photo were table stakes for credibility, this sample would show it. It does not.
+7. **Dormancy — 4 sites signal it in words, 8 let dates speak, 2 signal nothing.** The only unanimous finding is the negative one: nobody hides it.
+
+---
+
+## Implications for italovietro.com
+
+Grounded in the current repo state, which was read directly: `config.toml` (3 nav items per language, `[params.home.profile]` enabled with `avatarURL = "/images/avatar.png"` and a `typeit` subtitle, `[params.home.posts] enable = false`), `content/_index.en.md` (an existing `.home-routes` block with three described routes, followed by ~1,000 words of first-person prose in four sections), `assets/css/_override.scss` (`$single-link-color: #b45309` / `#f59e0b` dark, plus global-link-hover and pagination), and `static/images/logo.svg` (704 B, hexagon + steam + `>` chevron + coffee cup, single amber `#c2680a`).
+
+### 1. The homepage already routes. The question is what sits above the routes.
+
+The `.home-routes` block already does what macwright, maggieappleton, and brandur do — named sections with a one-line description each. That is not a gap. The gap is that ~1,000 words of biography sit *below* it, and **no site in the sample runs essay-length biography on its homepage.** The longest is 4 short paragraphs (thorstenball); yegge and tomcritchlow each use 3.
+
+Two supported options:
+
+- **Option A — contents-first (macwright, maggieappleton, brandur).** Routes near the top; biography cut to 2–4 paragraphs; the "What I've learned about people / teams / systems" material moves to a dedicated `/about/` page (which does not currently exist — the homepage *is* the about page). *Trade-off:* creating `/about/` means two new bilingual pages and a fourth nav item, taking EN and pt-BR to 4 items — still well under the sample median of 7. It also means the strongest writing on the site stops being the first thing a visitor sees.
+- **Option B — identity-first (yegge, thorstenball).** Portrait plus a tight 3-paragraph narrative, then the routes as tiles. *Trade-off:* both sample precedents are people with a commercial ask (advisory work; books). Given that a Speaking page exists and speaking invitations are a plausible goal, this is defensible — but it changes the site's posture from "here is my thinking" to "here is what I offer", and the sample shows that posture is the minority (3/14).
+
+What the evidence **rules out**: a feed-first homepage. All six feed-first sites have live feeds — danluu 197 items, simonwillison daily, lethain weekly, jvns monthly. Six posts with the newest from March 2021 cannot carry a feed. Keeping `[params.home.posts] enable = false` is correct and matches 8 of 14.
+
+### 2. Fix the section date format before anything else. This is the one clear defect.
+
+`config.toml` sets `[params.section] dateFormat = "01-02"` and `[params.list] dateFormat = "01-02"` — **month and day, no year.** Every dated site in the sample shows the year, without exception, down to danluu's 5-character `mm/yy`. A 2021 post rendered as `03-14` on `/posts/` reads as if it were published this March. For an archive the author is ambivalent about, a date format that hides the year is worse than no date at all: it does not merely fail to signal age, it actively misleads.
+
+Change both to a year-bearing format (`2006-01` or `2006-01-02`, matching the site-level `dateFormat` already set to `2006-01-02`). Zero translation cost. This is the highest-value change on the list and it is a one-line config edit.
+
+### 3. The archived writing section — three supported options, all additive.
+
+The unanimous finding is the negative one: **0 of 14 sites hide a dormant section.** So keeping `Writing` / `Artigos` in the nav is correct, and the existing route description — "Older posts on leadership, teams, and systems." / its pt-BR twin — is already doing the quiet-labelling job. Beyond that:
+
+- **Option C — the Collison notice (2/14 precedent, exact situational match).** A dated one-line banner at the top of `/posts/`, stating the last update and the ambivalence. Collison's wording is the template: *"As of mid 2026, this page has not been updated in around 10 years. It is currently kept around for posterity, though I may remove it at some stage."* An Italo version would read something like *"Last updated March 2021. Kept here because the ideas still hold, not because I'm still writing."* Cost: one sentence × 2 languages, in the section's `_index` front matter or a `content/posts/_index.*.md` file. *Trade-off:* it commits to a position in public. That is also its virtue — it converts an unexplained silence into a deliberate choice, and it matches Italo's actual ambivalence rather than papering over it.
+- **Option D — dates only (8/14, the plurality).** Do nothing but fix the date format (item 2). Thorsten Ball's `/talks` page has a 7-year gap between its two newest entries and says nothing about it; the dates carry it. *Trade-off:* it is the lowest-effort option and the most common, but it leaves a visitor to infer intent. With only 6 posts spanning a short window, the inference is easy to get wrong.
+- **Option E — a curation marker (6/14, the most common *active* response).** Mark which of the 6 still hold up. Yegge grades 150 essays with an emoji legend; lethain uses ⭐; jvns uses a `Favorites` nav item. With 6 posts a legend is overkill, but a single durable/star flag on the two or three that still stand is cheap and needs no translation. *Trade-off:* it requires an editorial judgement on each post — content work, not engineering. It also pairs well with C rather than competing with it.
+
+C and E combine cleanly (a dated notice plus flags on the survivors). D is the floor. Whichever, note that `Writing` / `Artigos` are already better labels than "Blog" — no dormant section in the sample is called "Blog", and both existing labels name an artefact rather than promising a cadence.
+
+### 4. Amber currently does 3 jobs. The evidence supports up to about 7, with one warning.
+
+`_override.scss` assigns `#b45309` / `#f59e0b` to link colour, global link hover, and pagination. The closest structural precedent in the sample is **yegge.ai**: one accent, lifted in dark (`#6b1d1d → #d97070`, mirroring amber's `#b45309 → #f59e0b`), doing seven jobs — links, one fragment of the wordmark, the active nav item, the CTA, `::selection`, the focus ring, and card hover borders.
+
+- **Option F — expand to 5 jobs.** Add the **active nav item** and **`::selection`**. Both have direct precedent (yegge for both; apenwarr colours the current nav item green for exactly this reason). Both are theme-agnostic, both need zero translation, and neither adds a visual element to the page — they only make an existing element legible. Cheapest personality gain available.
+- **Option G — stay at links only (3/14: patrickcollison, thorstenball, ciechanow).** Defensible and the most restrained reading. *Trade-off:* it leaves a distinctive asset underused.
+
+**The warning, and it is corroborated on both sides.** tomcritchlow — the sample's closest analogue for a single strong accent — keeps homepage post titles **black** and reserves green for section labels, prose links, and hover states. And `assets/css/_reading-list.scss` already records the same lesson from this repo's own history: *"amber stars, an amber '#' on every heading, an amber nav strip and amber titles"* was the state that had to be undone. External evidence agrees with the internal note. Whatever amber is expanded to, do not let it land on list titles *and* section labels *and* markers on the same surface. One accent job per surface.
+
+Note also that 4 of 14 sites (macwright, danluu, brandur, lethain) give links **no** colour at all, and macwright's variant is instructive: he reserves the coloured link for exactly one section (`/micro`). If amber ever feels like too much, confining it to one section rather than removing it is a precedented middle path.
+
+### 5. The logo is the best personality asset on hand, and it has a second role available.
+
+Only 1 of 14 sites uses an image logo in the header (apenwarr's wordmark JPEG). But **yegge reuses one abstract SVG mark in two places** — as an ornament on a pull-quote rule and as a footer mark — plus a `¶` as a closing mark. The mark earns more than one appearance when it is abstract rather than a name.
+
+- **Option H — header only (current).** Safe.
+- **Option I — header plus one ornament role.** A section divider on long pages, or an end-of-content mark. The asset is ideal for this: 704 bytes, single amber colour so it needs no dark-mode variant, clean vector so it scales to 16 px, and — critically — **it needs no translation.** Under a bilingual constraint, a mark is the cheapest possible way to add personality; every word costs double.
+- *Trade-off:* Italo's mark is semi-representational (a coffee cup, a `>` prompt). Yegge's works as decoration because it is abstract. Repeating a recognisable object risks reading as branding rather than typography. Mitigation: use only the hexagon outline or only the `>` chevron as the ornament, not the full mark.
+
+### 6. The portrait: 2 of 14, and both are selling something.
+
+The prism-streak portrait is a strong asset, but the sample gives no support for a face being necessary — 12 of 14, including every pure-writing site, show none. Note also that `[params.home.profile]` is currently `enable = true` with `avatarURL = "/images/avatar.png"` (428 KB PNG), while `content/_index.en.md` opens with its own `<h1>` and `.home-intro` — worth verifying whether the profile avatar and the markdown heading are both rendering, since the sample's identity-first sites (yegge, thorstenball) show a portrait *once*, not alongside a duplicate title.
+
+- **Option J — no portrait on the homepage** (12/14). Reserve it for a future `/about/` page, which is where lethain keeps his headshots (`/about/` offers four resolutions plus thumbnails, explicitly for event organisers — a directly copyable idea given a Speaking page exists).
+- **Option K — portrait in the first screen, yegge-style with a caption** (2/14). Defensible if inbound speaking invitations are a goal. *Trade-off:* the prism streak introduces the only non-amber colour on the site; check it does not fight `#b45309` / `#f59e0b`. Also budget the 428 KB PNG down.
+
+### 7. Speaking: 3 of 3 comparable sites separate talks from podcasts.
+
+thorstenball, yegge, and maggieappleton all keep `/talks` and `/podcasts` as distinct sections; none merges them. The current single `/speaking/` page merges both.
+
+- **Option L — one page, two clearly labelled groups.** Keep the nav slot and the bilingual page count; add a heading per group, a date and venue per entry, and a count. Every talks page in the sample carries a date and a venue per entry.
+- **Option M — split into two nav items.** EN and pt-BR each go to 4 items — still under the median. *Trade-off:* two more bilingual pages to maintain, and it splits a page that is currently coherent.
+
+Either way, two cheap borrowings apply. First, **the hedging one-liner**: 2 of 3 talks pages in the sample open with one — jvns's *"Here's a mostly up to date list of all the talks I've given"* and yegge's *"Most of my talks were never recorded, or the recordings have been lost."* One sentence, two languages, and it pre-empts the "is this complete?" question. Second, **the cross-link**: yegge's *"Long-form podcast conversations live on the Podcasts page"* is how a merged or split page tells a visitor where the other half is.
+
+Note the asymmetry Ball's site demonstrates and Italo's may share: **talks can be dormant while podcasts stay live.** If that is true here, the two halves want different treatment — which is an argument for Option M, or at minimum for dating both groups so the difference is visible rather than averaged away.
+
+### 8. Reading list: already ahead of most of the sample, with one free idea left.
+
+Star ratings are already implemented (per `_reading-list.scss`), which puts it in the 4-of-5 majority that rates or flags. Two additions have precedent:
+
+- **A read date per book** (macwright, maggieappleton). macwright's grid is `title | author | ISO date | star SVG` — four columns, no commentary. Zero translation cost.
+- **maggieappleton's Antilibrary** — a separate list of "Books I like the idea of having read". This is the one idea in the sample with no analogue on Italo's site, it is free content (books already on the shelf unread), and it needs only a heading translated. *Trade-off:* it is a distinctive move that reads as playful; it may or may not fit the site's register.
+
+### 9. What the sample says not to add.
+
+- **Comments** — 0/14. `[params.page.comment] enable = false` already matches.
+- **Consent banners and newsletter modals** — 0/14. Already off, with a good comment in `config.toml` explaining why.
+- **Iconised social rows** — 1/14. `[params.social]` is already down to GitHub, LinkedIn, RSS; the sample's dominant pattern is text links or prose mentions, not an icon strip.
+- **Search** — 10/14 omit it, and no `[params.search]` block exists, so LoveIt's search is off. That matches the majority. Note the counter-evidence: the two sites with the largest archives (simonwillison, gwern) both have search, so this is a function of archive size, not taste. At 6 posts, omitting it is right.
+- **Share buttons** — `[params.page.share]` currently enables Twitter, Facebook, HackerNews, **Line**, and **Weibo**. Line and Weibo are LoveIt defaults, not choices. This is an observation about the repo, not a finding from the sample (share buttons on post pages were not surveyed) — but no homepage in the sample carries share affordances, and two of the five enabled networks are implausible for a bilingual EN/pt-BR audience.
+
+### 10. The bilingual constraint reorders everything above.
+
+Nothing in the sample is bilingual, so there is no precedent to cite — but the constraint has a clear structural consequence: **prefer signals that carry no words.** Ranked by translation cost, using only mechanisms observed in the sample:
+
+| Cost | Mechanism | Seen at |
+|---|---|---|
+| **Zero** | Dates with the year; star / ⭐ / flag markers; the amber accent in more roles; the SVG mark as an ornament; count badges; `⇢` `⇠` `→` arrows; the active-nav-item colour; `::selection` | macwright, lethain, jvns, patrickcollison, yegge, maggieappleton, apenwarr |
+| **One line × 2** | A section description; a dated staleness notice; a talks-page completeness hedge; a cross-link between talks and podcasts | maggieappleton, patrickcollison, brandur, jvns, yegge |
+| **High** | Essay-length homepage prose (already ~1,000 words × 2 and growing) | nobody in the sample |
+
+Every high-confidence recommendation above — the date-format fix, expanding amber to the active nav item and `::selection`, a durable-post flag, the mark as an ornament — sits in the zero-cost row. The one-line-cost row holds the Collison notice and the talks hedge, both of which buy a lot for two sentences. The high-cost row is where the current homepage is over-invested relative to every site in the sample.
+
+---
+
+## Raw material
+
+Fetched HTML and CSS for all 14 sites, plus 14 subpages (`/talks`, `/podcasts`, `/library`, `/bookshelf`, `/now`, `/reading`, `/writing`, `/atlas`, `/about`), are in the session scratchpad at
+`/private/tmp/claude-502/-Users-italo-vietro-projects/87c97e7f-f8c1-4dba-b947-aa321c42d3c6/scratchpad/sites/`.
+These are session-scoped and will not persist; re-fetch from the URLs in Table 1 to verify any claim.

--- a/assets/css/_archive.scss
+++ b/assets/css/_archive.scss
@@ -1,0 +1,146 @@
+// ==============================
+// Archive (the writing list)
+// ==============================
+//
+// Styled to match the reading list and speaking pages: amber title because it is
+// the link, muted metadata, description at body size. Before this the page had a
+// right-aligned heading, grey titles that did not read as links, numeric dates,
+// and no descriptions at all -- which is why it had no presence next to the other
+// two.
+
+.archive {
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+// The theme right-aligns the archive title through `.archive .single-title`.
+// Matching that specificity is required; a bare `.single-title` rule loses.
+.archive .single-title {
+    text-align: left;
+    text-wrap: balance;
+}
+
+.archive-intro p {
+    font-size: 0.9375rem;
+    color: $muted-text-color;
+    margin: 0.5rem 0 0;
+}
+
+// --- Year groups ---------------------------------------------------------
+.archive .group-title {
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: $muted-text-color;
+    margin: 3rem 0 1.25rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid $global-border-color;
+}
+
+// --- Entries -------------------------------------------------------------
+// The theme sets `.archive .archive-item { display: flex; justify-content:
+// space-between }` for its one-line link-and-date layout, plus a 1.5rem left
+// margin. With a description added as a second child, flex laid the header and
+// the description out side by side and squeezed the title into a narrow column.
+// Block stacking is what this markup needs, and the specificity has to match the
+// theme's two-class selector.
+.archive .archive-item {
+    display: block;
+    margin: 0 0 1.75rem;
+}
+
+.archive-item__header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0 0.75rem;
+}
+
+.archive-item__title {
+    font-size: 1rem;
+    font-weight: 600;
+    line-height: 1.4;
+    text-wrap: balance;
+    margin: 0;
+}
+
+.archive-item__title a {
+    color: $single-link-color;
+    text-decoration: none;
+    transition: color $transition-base;
+}
+
+.archive-item__title a:hover {
+    color: $single-link-hover-color;
+    text-decoration: underline;
+    text-underline-offset: 3px;
+}
+
+.archive-item__date {
+    font-size: 0.8125rem;
+    color: $muted-text-color;
+    // Dates line up as a column when they are the same width.
+    font-variant-numeric: tabular-nums;
+}
+
+.archive-item__desc,
+.archive-item__desc p {
+    font-size: 0.9375rem;
+    line-height: 1.6;
+    color: $global-font-color;
+    margin: 0.25rem 0 0;
+}
+
+.archive-item__desc a {
+    color: $single-link-color;
+}
+
+.archive-item__desc a:hover {
+    color: $single-link-hover-color;
+}
+
+// --- Dark ----------------------------------------------------------------
+@mixin archive-dark {
+    .archive-intro p,
+    .archive .group-title,
+    .archive-item__date {
+        color: $muted-text-color-dark;
+    }
+
+    .archive .group-title {
+        border-bottom-color: $global-border-color-dark;
+    }
+
+    .archive-item__title a {
+        color: $single-link-color-dark;
+    }
+
+    .archive-item__title a:hover {
+        color: $single-link-hover-color-dark;
+    }
+
+    .archive-item__desc {
+        color: $global-font-color-dark;
+    }
+}
+
+[theme=dark] {
+    @include archive-dark;
+}
+
+@media (prefers-color-scheme: dark) {
+    [theme=auto] {
+        @include archive-dark;
+    }
+}
+
+// --- Mobile --------------------------------------------------------------
+@media (max-width: 680px) {
+    .archive .group-title {
+        margin-top: 2.5rem;
+    }
+
+    .archive-item__header {
+        flex-direction: column;
+        gap: 0.125rem;
+    }
+}

--- a/assets/css/_custom.scss
+++ b/assets/css/_custom.scss
@@ -55,6 +55,29 @@
     }
 }
 
+// Bold text carries emphasis by weight, not by a second colour.
+//
+// The theme sets `[theme=dark] .single .content b, strong { color: #ddd }` while
+// leaving bold alone in light mode. That gave dark mode two body text colours --
+// #a9a9b3 at 6.16:1 for prose and #ddd at 10.57:1 for bold -- so every bolded
+// company name in the bio read brighter than the sentence around it. Light mode
+// never had the problem.
+//
+// Body text already clears AA at 6.16:1, so bold comes down to match rather than
+// prose going up. The theme's more specific rule for bold inside links is left
+// intact, so a bolded link still takes the accent.
+[theme=dark] .single .content b,
+[theme=dark] .single .content strong {
+    color: inherit;
+}
+
+@media (prefers-color-scheme: dark) {
+    [theme=auto] .single .content b,
+    [theme=auto] .single .content strong {
+        color: inherit;
+    }
+}
+
 @import "home";
 @import "reading-list";
 @import "speaking";

--- a/assets/css/_custom.scss
+++ b/assets/css/_custom.scss
@@ -3,8 +3,12 @@
 // 自定义样式
 // ==============================
 /* assets/css/custom.css */
+// Was margin-top: 13rem. That existed to compensate for the theme pushing the
+// profile block down by translateY(16vh) -- two hacks cancelling each other, with
+// the result depending on viewport height. The transform is reset in _home.scss,
+// so this no longer needs to make room for anything.
 .home-content {
-    margin-top: 13rem;
+    margin-top: 2rem;
 }
 
 // Logo styling
@@ -51,6 +55,7 @@
     }
 }
 
+@import "home";
 @import "reading-list";
 @import "speaking";
 @import "interactions";

--- a/assets/css/_custom.scss
+++ b/assets/css/_custom.scss
@@ -79,6 +79,7 @@
 }
 
 @import "home";
+@import "archive";
 @import "reading-list";
 @import "speaking";
 @import "interactions";

--- a/assets/css/_home.scss
+++ b/assets/css/_home.scss
@@ -1,0 +1,188 @@
+// ==============================
+// Home page
+// ==============================
+//
+// The page previously stacked two alignment systems: a centered block of avatar,
+// tagline and social icons, then left-aligned prose underneath. Both reference
+// points for this design commit to one axis -- yegge.ai centres throughout,
+// macwright.com left-aligns throughout. This picks left, because the bio and the
+// section list below are left-aligned and they are the substance.
+//
+// It also led with biography and routed nowhere. Six published posts sat live at
+// /posts/ with nothing linking to them. The route list below is the fix: the
+// homepage now points at the work first, in the manner of yegge.ai's showcase
+// cards, and keeps the bio underneath for anyone who wants it.
+
+.home .home-profile {
+    text-align: left;
+    padding-top: 2rem;
+    margin-bottom: 0;
+
+    // The theme pushes this block down by translateY(16vh) to vertically centre a
+    // profile-style home page. That left roughly 210px of empty space under the
+    // header, and made the gap depend on viewport height, which is why the
+    // content below carried a matching 13rem top margin to compensate. Resetting
+    // the transform removes both halves of that arrangement.
+    transform: none;
+}
+
+// Smaller, and no longer the largest thing on the page. It carries the human
+// signal without becoming the headline.
+//
+// The theme's .5rem padding on the wrapper pushed the avatar 8px right of the
+// text column, so nothing quite lined up on the left edge. Zeroing it puts the
+// portrait, the subtitle, the prose and the route rows on one axis.
+.home .home-avatar {
+    padding: 0;
+}
+
+.home .home-avatar img {
+    width: 88px;
+    height: 88px;
+    margin: 0;
+}
+
+.home .home-subtitle,
+.home .links {
+    padding-left: 0;
+}
+
+.home .home-subtitle {
+    text-align: left;
+    font-size: 1rem;
+    margin: 1rem 0 0;
+}
+
+// Social icons are the least interesting thing here and were the first
+// interactive elements a visitor met. yegge.ai omits them outright; this keeps
+// them, quiet and after the subtitle rather than beneath a centred portrait.
+.home .links {
+    text-align: left;
+    margin-top: 0.75rem;
+}
+
+.home .links a {
+    color: $muted-text-color;
+    font-size: 1rem;
+    margin-right: 0.875rem;
+    transition: color $transition-base;
+}
+
+.home .links a:hover {
+    color: $single-link-color;
+}
+
+// --- Route list ----------------------------------------------------------
+//
+// Three destinations, each with one line saying what is there. Rows rather than
+// cards: a card is a box drawn around text, and at three items the box earns
+// nothing that a rule and some space do not already do.
+.home-routes {
+    display: flex;
+    flex-direction: column;
+    margin: 2.5rem 0 0;
+    border-top: 1px solid $global-border-color;
+}
+
+.home-route {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0 0.75rem;
+    padding: 0.875rem 0.5rem 0.875rem 0;
+    border-bottom: 1px solid $global-border-color;
+    text-decoration: none;
+    transition:
+        background-color $transition-base,
+        padding-left $transition-base;
+}
+
+.home-route__name {
+    font-size: 1.0625rem;
+    font-weight: 600;
+    color: $single-link-color;
+}
+
+.home-route__desc {
+    font-size: 0.9375rem;
+    color: $muted-text-color;
+}
+
+// Gated to real pointers so a tap does not leave a row stuck in hover state.
+@media (hover: hover) {
+    .home-route:hover {
+        background-color: rgba($single-link-color, 0.06);
+        padding-left: 0.5rem;
+    }
+
+    .home-route:hover .home-route__name {
+        color: $single-link-hover-color;
+        text-decoration: underline;
+        text-underline-offset: 3px;
+    }
+}
+
+.home-route:focus-visible {
+    background-color: rgba($single-link-color, 0.06);
+}
+
+// --- Dark ----------------------------------------------------------------
+@mixin home-dark {
+    .home .links a {
+        color: $muted-text-color-dark;
+    }
+
+    .home .links a:hover {
+        color: $single-link-color-dark;
+    }
+
+    .home-routes,
+    .home-route {
+        border-color: $global-border-color-dark;
+    }
+
+    .home-route__name {
+        color: $single-link-color-dark;
+    }
+
+    .home-route__desc {
+        color: $muted-text-color-dark;
+    }
+
+    @media (hover: hover) {
+        .home-route:hover {
+            background-color: rgba($single-link-color-dark, 0.1);
+        }
+
+        .home-route:hover .home-route__name {
+            color: $single-link-hover-color-dark;
+        }
+    }
+
+    .home-route:focus-visible {
+        background-color: rgba($single-link-color-dark, 0.1);
+    }
+}
+
+[theme=dark] {
+    @include home-dark;
+}
+
+@media (prefers-color-scheme: dark) {
+    [theme=auto] {
+        @include home-dark;
+    }
+}
+
+// --- Mobile --------------------------------------------------------------
+@media (max-width: 680px) {
+    .home .home-avatar img {
+        width: 72px;
+        height: 72px;
+    }
+
+    .home-route {
+        flex-direction: column;
+        gap: 0.125rem;
+    }
+}

--- a/assets/css/_reading-list.scss
+++ b/assets/css/_reading-list.scss
@@ -1,38 +1,64 @@
 // ==============================
 // Reading List Styles
 // ==============================
+//
+// Two entry weights, one accent colour.
+//
+// The page previously gave twenty entries identical visual weight, then added 86
+// amber stars, an amber "#" on every heading, an amber nav strip and amber titles
+// -- four unrelated jobs for one colour, so nothing read as more important than
+// anything else. That, rather than any single style, is what made it feel chaotic.
+//
+// Now: amber marks entry titles, which are the links, and hover states. Section
+// headings, the nav strip and metadata are all quiet by default. Hierarchy comes
+// from size and space instead of from colour.
+//
+// Colours here use the $muted-text-color tokens rather than the theme's
+// $global-font-secondary-color. That variable measures 2.33:1 in light and 2.18:1
+// in dark -- both well under AA -- which is why the old tier labels and author
+// names looked washed out rather than merely subtle.
 
-// Light mode (default)
+// --- Column --------------------------------------------------------------
 .single .content {
     max-width: 800px;
     margin: 0 auto;
 }
 
+// The theme right-aligns the title on "special" pages via
+// `.special .single-title`, which reads as a mistake on a content page. Matching
+// that selector's specificity is required -- a bare `.single-title` rule loses
+// even though it is declared later. Blog posts are unaffected: they are not
+// .special, so their titles were never right-aligned.
+.special .single-title {
+    text-align: left;
+}
+
+// --- Section headings ----------------------------------------------------
 .single .content h2 {
-    font-size: 2rem;
-    margin-top: 3rem;
-    margin-bottom: 1.5rem;
+    font-size: 1.75rem;
+    font-weight: 700;
+    text-wrap: balance;
+    margin-top: 4rem;
+    margin-bottom: 0.5rem;
     padding-bottom: 0.75rem;
-    border-bottom: 3px solid $global-border-color;
+    border-bottom: 1px solid $global-border-color;
     color: $global-font-color;
 }
 
-// Tier labels (h3 within category sections) — per D-08, D-09, LAYOUT-02
-.single .content h3 {
-    font-size: 0.8125rem;
-    font-weight: 600;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: $global-font-secondary-color;
-    margin-top: 32px;
-    margin-bottom: 12px;
+// The theme's JS injects a "#" before each h2, inheriting the link colour. It
+// reads as markdown that failed to render, and it was one of amber's four jobs.
+.single .content > h2 > .header-mark {
+    display: none;
 }
 
-.single .content > ul {
-    padding-left: 0;
-    list-style: none;
+// The line under each section heading.
+.single .content h2 + p {
+    font-size: 0.9375rem;
+    color: $muted-text-color;
+    margin: 0 0 2rem;
 }
 
+// --- Intro ---------------------------------------------------------------
 .single .content > p:first-of-type {
     font-size: 1.1rem;
     line-height: 1.8;
@@ -45,13 +71,21 @@
     border-top: 1px solid $global-border-color;
 }
 
-// Anchor nav — plain text links with separator dots (Phase 3)
+// --- Section nav ---------------------------------------------------------
+//
+// Quiet by default. Four amber links in a row was a stripe of colour competing
+// with the entry titles for no reason -- these are wayfinding, not destinations.
+.single .content > ul {
+    padding-left: 0;
+    list-style: none;
+}
+
 .single .content > ul:first-of-type {
     display: flex;
     flex-wrap: wrap;
     list-style: none;
     padding: 0;
-    margin: 0 0 2rem 0;
+    margin: 0 0 3rem 0;
 }
 
 .single .content > ul:first-of-type li {
@@ -61,41 +95,37 @@
 
 .single .content > ul:first-of-type li:not(:first-child)::before {
     content: "\00B7";
-    color: $global-font-secondary-color;
-    padding: 0 4px;
+    color: $muted-text-color;
+    padding: 0 6px;
 }
 
 .single .content > ul:first-of-type li a {
     font-size: 0.875rem;
-    color: $single-link-color;
+    color: $muted-text-color;
     text-decoration: none;
     padding: 0;
     background: none;
     border-radius: 0;
     font-weight: 400;
-    transition: color 0.2s ease;
+    transition: color $transition-base;
 }
 
 .single .content > ul:first-of-type li a:hover {
-    color: $single-link-hover-color;
+    color: $single-link-color;
+    text-decoration: underline;
+    text-underline-offset: 3px;
 }
 
-// Book entry — typography-driven, no cards (per D-02)
-.single .content .book-entry {
-    margin-bottom: 24px;
-}
-
+// --- Entries, shared -----------------------------------------------------
 .single .content .book-entry__title {
-    font-size: 1.125rem;
-    font-weight: 600;
-    margin-bottom: 4px;
-    line-height: 1.3;
+    text-wrap: balance;
+    margin: 0;
 }
 
 .single .content .book-entry__title a {
     color: $single-link-color;
     text-decoration: none;
-    transition: color 0.2s ease;
+    transition: color $transition-base;
 }
 
 .single .content .book-entry__title a:hover {
@@ -103,136 +133,137 @@
 }
 
 .single .content .book-entry__author {
-    font-size: 0.8125rem;
-    color: $global-font-secondary-color;
-    margin-bottom: 8px;
-    display: block;
+    color: $muted-text-color;
 }
 
 .single .content .book-entry__description {
+    color: $global-font-color;
+    margin: 0;
+}
+
+// --- Compact entries (the default) ---------------------------------------
+//
+// Title and author share a line, which is where the density comes from. Long
+// author lists wrap naturally rather than being pushed out of the row.
+.single .content .book-entry {
+    margin-bottom: 1.75rem;
+}
+
+.single .content .book-entry__header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0 0.5rem;
+}
+
+.single .content .book-entry__title {
     font-size: 1rem;
-    line-height: 1.5;
-    color: $global-font-color;
+    font-weight: 600;
+    line-height: 1.4;
 }
 
-// Star ratings — inline with title (per D-01, D-03, D-04)
-.single .content .book-entry__rating {
-    margin-left: 8px;
-    vertical-align: middle;
-    display: inline;
+.single .content .book-entry__author {
+    font-size: 0.8125rem;
 }
 
-.single .content .book-entry__rating .fa-star {
-    font-size: 0.75rem;
-    color: $single-link-color;
-    letter-spacing: 2px;
+// No separator glyph between title and author. A "·" here orphans itself at the
+// start of the next line whenever a long author list wraps -- "Site Reliability
+// Engineering" has four authors and did exactly that. CSS cannot detect wrapping,
+// so the size and colour difference does the separating instead.
+
+.single .content .book-entry__description {
+    font-size: 0.9375rem;
+    line-height: 1.6;
+    margin-top: 0.25rem;
 }
 
-// Dark mode
-[theme=dark] .single .content h2 {
-    border-bottom-color: $global-border-color-dark;
-    color: $global-font-color-dark;
+// --- Featured entries ----------------------------------------------------
+//
+// The answer to "what should I read?" gets room to breathe: a bigger title, the
+// author on its own line, and the description at full reading size. An accent
+// edge groups them without turning them into cards.
+.single .content .book-entry--featured {
+    margin-bottom: 2.5rem;
+    padding-left: 1.25rem;
+    border-left: 2px solid $global-border-color;
 }
 
-[theme=dark] .single .content h3 {
-    color: $global-font-secondary-color-dark;
+.single .content .book-entry--featured .book-entry__header {
+    display: block;
 }
 
-[theme=dark] .single .content > hr {
-    border-top-color: $global-border-color-dark;
+.single .content .book-entry--featured .book-entry__title {
+    font-size: 1.3125rem;
+    font-weight: 700;
+    line-height: 1.3;
 }
 
-[theme=dark] .single .content > ul:first-of-type li:not(:first-child)::before {
-    color: $global-font-secondary-color-dark;
+.single .content .book-entry--featured .book-entry__author {
+    display: block;
+    font-size: 0.875rem;
+    margin-top: 0.25rem;
 }
 
-[theme=dark] .single .content > ul:first-of-type li a {
-    color: $single-link-color-dark;
-    background: none;
+.single .content .book-entry--featured .book-entry__description {
+    font-size: 1.0625rem;
+    line-height: 1.7;
+    margin-top: 0.625rem;
 }
 
-[theme=dark] .single .content > ul:first-of-type li a:hover {
-    color: $single-link-hover-color-dark;
-}
-
-[theme=dark] .single .content .book-entry__title a {
-    color: $single-link-color-dark;
-}
-
-[theme=dark] .single .content .book-entry__title a:hover {
-    color: $single-link-hover-color-dark;
-}
-
-[theme=dark] .single .content .book-entry__author {
-    color: $global-font-secondary-color-dark;
-}
-
-[theme=dark] .single .content .book-entry__description {
-    color: $global-font-color-dark;
-}
-
-[theme=dark] .single .content .book-entry__rating .fa-star {
-    color: $single-link-color-dark;
-}
-
-// Auto theme
-[theme=auto] .single .content h2 {
-    border-bottom-color: $global-border-color;
-    color: $global-font-color;
-}
-
-@media (prefers-color-scheme: dark) {
-    [theme=auto] .single .content h2 {
+// --- Dark ----------------------------------------------------------------
+@mixin reading-list-dark {
+    .single .content h2 {
         border-bottom-color: $global-border-color-dark;
         color: $global-font-color-dark;
     }
 
-    [theme=auto] .single .content h3 {
-        color: $global-font-secondary-color-dark;
+    .single .content h2 + p,
+    .single .content > ul:first-of-type li:not(:first-child)::before,
+    .single .content > ul:first-of-type li a,
+    .single .content .book-entry__author {
+        color: $muted-text-color-dark;
     }
 
-    [theme=auto] .single .content > hr {
+    .single .content > ul:first-of-type li a:hover {
+        color: $single-link-color-dark;
+    }
+
+    .single .content > hr {
         border-top-color: $global-border-color-dark;
     }
 
-    [theme=auto] .single .content > ul:first-of-type li:not(:first-child)::before {
-        color: $global-font-secondary-color-dark;
-    }
-
-    [theme=auto] .single .content > ul:first-of-type li a {
-        color: $single-link-color-dark;
-        background: none;
-    }
-
-    [theme=auto] .single .content > ul:first-of-type li a:hover {
-        color: $single-link-hover-color-dark;
-    }
-
-    [theme=auto] .single .content .book-entry__title a {
+    .single .content .book-entry__title a {
         color: $single-link-color-dark;
     }
 
-    [theme=auto] .single .content .book-entry__title a:hover {
+    .single .content .book-entry__title a:hover {
         color: $single-link-hover-color-dark;
     }
 
-    [theme=auto] .single .content .book-entry__author {
-        color: $global-font-secondary-color-dark;
-    }
-
-    [theme=auto] .single .content .book-entry__description {
+    .single .content .book-entry__description {
         color: $global-font-color-dark;
     }
 
-    [theme=auto] .single .content .book-entry__rating .fa-star {
-        color: $single-link-color-dark;
+    .single .content .book-entry--featured {
+        border-left-color: $global-border-color-dark;
     }
 }
 
-// Mobile breakpoint (aligned with LoveIt 680px breakpoint)
+[theme=dark] {
+    @include reading-list-dark;
+}
+
+@media (prefers-color-scheme: dark) {
+    [theme=auto] {
+        @include reading-list-dark;
+    }
+}
+
+// --- Mobile --------------------------------------------------------------
 @media (max-width: 680px) {
     .single .content h2 {
-        font-size: 1.6rem;
+        font-size: 1.5rem;
+        margin-top: 3rem;
     }
 
     .single .content > ul:first-of-type {
@@ -250,7 +281,15 @@
         text-align: left;
     }
 
-    .single .content .book-entry__title {
+    .single .content .book-entry--featured {
+        padding-left: 1rem;
+    }
+
+    .single .content .book-entry--featured .book-entry__title {
+        font-size: 1.1875rem;
+    }
+
+    .single .content .book-entry--featured .book-entry__description {
         font-size: 1rem;
     }
 }

--- a/assets/css/_reading-list.scss
+++ b/assets/css/_reading-list.scss
@@ -52,14 +52,27 @@
 }
 
 // The line under each section heading.
-.single .content h2 + p {
+//
+// Scoped with :has(.book-entry) so it only applies on this page. Unscoped, it
+// matched `h2 + p` on every .single page -- which on the home page meant the
+// first body paragraph after each "What I've learned about..." heading rendered
+// at 15px and muted while the paragraphs below it stayed at the 16px default.
+// A one-pixel inconsistency, visible, and reported.
+//
+// If :has() is unavailable the rule simply does not apply and these lines render
+// as ordinary paragraphs, which is a safe way to fail.
+.single .content:has(.book-entry) h2 + p {
     font-size: 0.9375rem;
     color: $muted-text-color;
     margin: 0 0 2rem;
 }
 
 // --- Intro ---------------------------------------------------------------
-.single .content > p:first-of-type {
+//
+// Also scoped. It did not reach the home page, whose paragraphs sit inside a
+// .home-content wrapper rather than directly under .content, but it did apply to
+// the speaking page and to every blog post.
+.single .content:has(.book-entry) > p:first-of-type {
     font-size: 1.1rem;
     line-height: 1.8;
     margin-bottom: 2rem;

--- a/config.toml
+++ b/config.toml
@@ -35,7 +35,7 @@ ignoreLogs = ['shortcode-twitter-getremote']
         identifier = "reading-list"
         pre = ""
         post = ""
-        name = "What I'm Reading"
+        name = "Reading"
         url = "/recommended-reading/"
         title = ""
         weight = 2
@@ -106,7 +106,7 @@ ignoreLogs = ['shortcode-twitter-getremote']
         identifier = "reading-list"
         pre = ""
         post = ""
-        name = "O que estou lendo"
+        name = "Leituras"
         url = "/leituras-recomendadas/"
         title = ""
         weight = 2
@@ -200,8 +200,9 @@ ignoreLogs = ['shortcode-twitter-getremote']
   [params.section]
     # special amount of posts in each section page
     paginate = 20
-    # date format (month and day)
-    dateFormat = "01-02"
+    # The archive groups by year, so the year is already on screen. "January 2"
+    # reads as a date; "01-02" reads as a code.
+    dateFormat = "January 2"
     # amount of RSS pages
     rss = 10
 

--- a/config.toml
+++ b/config.toml
@@ -210,8 +210,10 @@ ignoreLogs = ['shortcode-twitter-getremote']
   [params.list]
     # special amount of posts in each list page
     paginate = 20
-    # date format (month and day)
-    dateFormat = "01-02"
+    # Year-bearing, like the section format. Every dated site in the reference
+    # survey shows the year without exception; "01-02" made a 2021 post read as
+    # if it were published this year.
+    dateFormat = "2006-01-02"
     # amount of RSS pages
     rss = 10
 

--- a/config.toml
+++ b/config.toml
@@ -20,6 +20,17 @@ ignoreLogs = ['shortcode-twitter-getremote']
     copyright = "italo Vietro."
       
     [languages.en.menu]
+      # Writing was missing entirely. Six published posts sat live and indexed at
+      # /posts/ with nothing linking to them from the nav or the homepage, so a
+      # visitor arriving at the domain had no path to any of them.
+      [[languages.en.menu.main]]
+        identifier = "writing"
+        pre = ""
+        post = ""
+        name = "Writing"
+        url = "/posts/"
+        title = ""
+        weight = 1
       [[languages.en.menu.main]]
         identifier = "reading-list"
         pre = ""
@@ -27,7 +38,7 @@ ignoreLogs = ['shortcode-twitter-getremote']
         name = "What I'm Reading"
         url = "/recommended-reading/"
         title = ""
-        weight = 1
+        weight = 2
       [[languages.en.menu.main]]
         identifier = "speaking"
         pre = ""
@@ -35,7 +46,7 @@ ignoreLogs = ['shortcode-twitter-getremote']
         name = "Speaking"
         url = "/speaking/"
         title = ""
-        weight = 2
+        weight = 3
     [languages.en.pagination]
       disableAliases = true
       pagerSize = 12
@@ -84,20 +95,28 @@ ignoreLogs = ['shortcode-twitter-getremote']
     copyright = "italovietro"
     [languages.pt-br.menu]
       [[languages.pt-br.menu.main]]
+        identifier = "writing"
+        pre = ""
+        post = ""
+        name = "Artigos"
+        url = "/posts/"
+        title = ""
+        weight = 1
+      [[languages.pt-br.menu.main]]
         identifier = "reading-list"
         pre = ""
         post = ""
         name = "O que estou lendo"
         url = "/leituras-recomendadas/"
         title = ""
-        weight = 1
+        weight = 2
       [[languages.pt-br.menu.main]]
         identifier = "palestras"
         pre = ""
         name = "Palestras"
         url = "/palestras/"
         title = ""
-        weight = 2
+        weight = 3
     [languages.pt-br.pagination]
       disableAliases = true
       pagerSize = 12

--- a/content/_index.en.md
+++ b/content/_index.en.md
@@ -14,7 +14,7 @@ I'm Senior Director of Engineering at <strong><a href="https://parloa.com">Parlo
 <nav class="home-routes" aria-label="Sections">
   <a class="home-route" href="/posts/">
     <span class="home-route__name">Writing</span>
-    <span class="home-route__desc">Posts on leadership, teams, and systems.</span>
+    <span class="home-route__desc">Older posts on leadership, teams, and systems.</span>
   </a>
   <a class="home-route" href="/recommended-reading/">
     <span class="home-route__name">What I'm Reading</span>

--- a/content/_index.en.md
+++ b/content/_index.en.md
@@ -11,6 +11,21 @@ description: "Senior Director of Engineering at Parloa. 18+ years building softw
 I'm Senior Director of Engineering at <strong><a href="https://parloa.com">Parloa</a></strong>, where we're figuring out how to make AI conversations actually work reliably at scale. The kind of problem where "move fast and break things" doesn't fly. I've been in tech for 18+ years. Started fixing computers in João Pessoa, Brazil, eventually moved into software, and made my way across Europe building teams and systems.
 </p>
 
+<nav class="home-routes" aria-label="Sections">
+  <a class="home-route" href="/posts/">
+    <span class="home-route__name">Writing</span>
+    <span class="home-route__desc">Posts on leadership, teams, and systems.</span>
+  </a>
+  <a class="home-route" href="/recommended-reading/">
+    <span class="home-route__name">What I'm Reading</span>
+    <span class="home-route__desc">The books, newsletters, and podcasts that stuck.</span>
+  </a>
+  <a class="home-route" href="/speaking/">
+    <span class="home-route__name">Speaking</span>
+    <span class="home-route__desc">Talks, panels, and podcast appearances.</span>
+  </a>
+</nav>
+
 ---
 
 ## What I've learned about people

--- a/content/_index.en.md
+++ b/content/_index.en.md
@@ -17,7 +17,7 @@ I'm Senior Director of Engineering at <strong><a href="https://parloa.com">Parlo
     <span class="home-route__desc">Older posts on leadership, teams, and systems.</span>
   </a>
   <a class="home-route" href="/recommended-reading/">
-    <span class="home-route__name">What I'm Reading</span>
+    <span class="home-route__name">Reading</span>
     <span class="home-route__desc">The books, newsletters, and podcasts that stuck.</span>
   </a>
   <a class="home-route" href="/speaking/">

--- a/content/_index.pt-br.md
+++ b/content/_index.pt-br.md
@@ -11,6 +11,21 @@ description: "Senior Director of Engineering na Parloa. 18+ anos construindo sof
 Sou Senior Director of Engineering na <strong><a href="https://parloa.com">Parloa</a></strong>, onde a gente tá descobrindo como fazer conversas com IA funcionarem de verdade em escala. O tipo de problema onde "move fast and break things" não cola. Estou na área de tecnologia há 18+ anos. Comecei consertando computadores em João Pessoa, migrei para software, e fui fazendo meu caminho pela Europa construindo times e sistemas.
 </p>
 
+<nav class="home-routes" aria-label="Seções">
+  <a class="home-route" href="/pt-br/posts/">
+    <span class="home-route__name">Artigos</span>
+    <span class="home-route__desc">Textos sobre liderança, times e sistemas.</span>
+  </a>
+  <a class="home-route" href="/pt-br/leituras-recomendadas/">
+    <span class="home-route__name">O que estou lendo</span>
+    <span class="home-route__desc">Os livros, newsletters e podcasts que ficaram.</span>
+  </a>
+  <a class="home-route" href="/pt-br/palestras/">
+    <span class="home-route__name">Palestras</span>
+    <span class="home-route__desc">Palestras, painéis e participações em podcasts.</span>
+  </a>
+</nav>
+
 ---
 
 ## O que aprendi sobre pessoas

--- a/content/_index.pt-br.md
+++ b/content/_index.pt-br.md
@@ -17,7 +17,7 @@ Sou Senior Director of Engineering na <strong><a href="https://parloa.com">Parlo
     <span class="home-route__desc">Textos antigos sobre liderança, times e sistemas.</span>
   </a>
   <a class="home-route" href="/pt-br/leituras-recomendadas/">
-    <span class="home-route__name">O que estou lendo</span>
+    <span class="home-route__name">Leituras</span>
     <span class="home-route__desc">Os livros, newsletters e podcasts que ficaram.</span>
   </a>
   <a class="home-route" href="/pt-br/palestras/">

--- a/content/_index.pt-br.md
+++ b/content/_index.pt-br.md
@@ -14,7 +14,7 @@ Sou Senior Director of Engineering na <strong><a href="https://parloa.com">Parlo
 <nav class="home-routes" aria-label="Seções">
   <a class="home-route" href="/pt-br/posts/">
     <span class="home-route__name">Artigos</span>
-    <span class="home-route__desc">Textos sobre liderança, times e sistemas.</span>
+    <span class="home-route__desc">Textos antigos sobre liderança, times e sistemas.</span>
   </a>
   <a class="home-route" href="/pt-br/leituras-recomendadas/">
     <span class="home-route__name">O que estou lendo</span>

--- a/content/posts/_index.en.md
+++ b/content/posts/_index.en.md
@@ -1,0 +1,6 @@
+---
+title: "Writing"
+description: "Posts from 2018 to 2021 on leadership, teams, and systems."
+---
+
+Posts from 2018 to 2021 on leadership, teams, and systems.

--- a/content/posts/_index.pt-br.md
+++ b/content/posts/_index.pt-br.md
@@ -1,0 +1,6 @@
+---
+title: "Artigos"
+description: "Textos de 2018 a 2021 sobre liderança, times e sistemas."
+---
+
+Textos de 2018 a 2021 sobre liderança, times e sistemas.

--- a/content/recommended-reading/index.en.md
+++ b/content/recommended-reading/index.en.md
@@ -13,75 +13,60 @@ This isn't a complete list—just the ones that stuck. The ones I return to. The
 
 ---
 
-* [Currently Reading](#currently-reading)
-* [Engineering Books](#engineering-books)
-* [Management Books](#management-books)
+* [Start Here](#start-here)
+* [More Books](#more-books)
 * [Newsletters](#newsletters)
 * [Podcasts](#podcasts)
 
-## Currently Reading
+## Start Here
 
-{{< book title="[Book Title]" author="[Author Name]" link="https://example.com" type="book" >}}
-[Why I'm reading this -- replace with your current read.]
-{{< /book >}}
+The ones I hand over first.
 
-## Engineering Books
-
-Books that changed how I write code and think about systems.
-
-### Must Read
-
-{{< book title="Clean Code" author="Robert C. Martin" link="https://amzn.to/3f4tfO8" type="book" rating="5" >}}
+{{< book title="Clean Code" author="Robert C. Martin" link="https://amzn.to/3f4tfO8" type="book" featured="true" >}}
 Read this five years into my career. Changed everything about how I approached readability, testing, and maintenance. Stop writing code for compilers; write it for humans.
 {{< /book >}}
 
-{{< book title="Domain-Driven Design" author="Eric Evans" link="https://amzn.to/32NQx63" type="book" rating="5" >}}
+{{< book title="Domain-Driven Design" author="Eric Evans" link="https://amzn.to/32NQx63" type="book" featured="true" >}}
 The book that taught me to speak business language in code. Ubiquitous language and bounded contexts aren't buzzwords—they're how you survive complex domains without losing your mind.
 {{< /book >}}
 
-{{< book title="Grokking Algorithms" author="Aditya Bhargava" link="https://amzn.to/3pvir0o" type="book" rating="5" >}}
+{{< book title="Grokking Algorithms" author="Aditya Bhargava" link="https://amzn.to/3pvir0o" type="book" featured="true" >}}
 The algorithms book that doesn't feel like homework. Clear examples, digestible chunks. Perfect refresher before interviews or when you need to remember why hash tables exist.
 {{< /book >}}
 
-### Recommended
-
-{{< book title="Refactoring" author="Martin Fowler" link="https://amzn.to/3lDbNmG" type="book" rating="4" >}}
-Martin Fowler's catalog of "how to improve code without breaking it." I still reference specific patterns from this book when reviewing PRs.
-{{< /book >}}
-
-{{< book title="Clean Architecture" author="Robert C. Martin" link="https://amzn.to/3f4tfO8" type="book" rating="4" >}}
-Uncle Bob's follow-up to Clean Code. Less about code, more about structure. Helps you avoid the architectural mistakes I made early in my career.
-{{< /book >}}
-
-{{< book title="Site Reliability Engineering" author="Betsy Beyer, Chris Jones, Jennifer Petoff, Niall Richard Murphy" link="https://amzn.to/3kzDD1R" type="book" rating="4" >}}
-Google's SRE bible. First half will feel familiar if you've done on-call. Remember: what works at Google scale might be overkill for you. But the principles? Solid.
-{{< /book >}}
-
-{{< book title="Staff Engineer" author="Will Larson" link="https://amzn.eu/d/cAtTpf3" type="book" rating="4" >}}
-Hit differently when I was navigating the IC vs management fork. Practical roadmap for senior ICs who want impact without the title inflation.
-{{< /book >}}
-
-## Management Books
-
-The books that helped me not suck at leading people.
-
-### Must Read
-
-{{< book title="The Manager's Path" author="Camille Fournier" link="https://amzn.to/3f0FnzM" type="book" rating="5" >}}
+{{< book title="The Manager's Path" author="Camille Fournier" link="https://amzn.to/3f0FnzM" type="book" featured="true" >}}
 Your roadmap from tech lead to CTO. Camille Fournier nails every stage. I reread different chapters depending on where I am. Currently dog-earing the VP section.
 {{< /book >}}
 
-{{< book title="An Elegant Puzzle" author="Will Larson" link="https://amzn.to/3kHB3Hb" type="book" rating="5" >}}
+{{< book title="An Elegant Puzzle" author="Will Larson" link="https://amzn.to/3kHB3Hb" type="book" featured="true" >}}
 Will Larson's guide is the most practical engineering management book I've found. Real tactics for hiring, team dynamics, and scaling orgs. The appendix alone is worth the price—a goldmine of paper recommendations.
 {{< /book >}}
 
-{{< book title="The Phoenix Project" author="Gene Kim, Kevin Behr, George Spafford" link="https://amzn.to/3kyPsVU" type="book" rating="5" >}}
+{{< book title="The Phoenix Project" author="Gene Kim, Kevin Behr, George Spafford" link="https://amzn.to/3kyPsVU" type="book" featured="true" >}}
 DevOps wrapped in a novel. Sounds cheesy, but it works. Read this when you're struggling to explain why "just ship faster" isn't a strategy.
 {{< /book >}}
 
-### Recommended
+## More Books
 
-{{< book title="The Engineering Executive's Primer" author="Will Larson" link="https://amzn.eu/d/2ET5UiD" type="book" rating="4" >}}
+Books that changed how I write code, and the ones that helped me not suck at leading people.
+
+{{< book title="Refactoring" author="Martin Fowler" link="https://amzn.to/3lDbNmG" type="book" >}}
+Martin Fowler's catalog of "how to improve code without breaking it." I still reference specific patterns from this book when reviewing PRs.
+{{< /book >}}
+
+{{< book title="Clean Architecture" author="Robert C. Martin" link="https://amzn.to/3f4tfO8" type="book" >}}
+Uncle Bob's follow-up to Clean Code. Less about code, more about structure. Helps you avoid the architectural mistakes I made early in my career.
+{{< /book >}}
+
+{{< book title="Site Reliability Engineering" author="Betsy Beyer, Chris Jones, Jennifer Petoff, Niall Richard Murphy" link="https://amzn.to/3kzDD1R" type="book" >}}
+Google's SRE bible. First half will feel familiar if you've done on-call. Remember: what works at Google scale might be overkill for you. But the principles? Solid.
+{{< /book >}}
+
+{{< book title="Staff Engineer" author="Will Larson" link="https://amzn.eu/d/cAtTpf3" type="book" >}}
+Hit differently when I was navigating the IC vs management fork. Practical roadmap for senior ICs who want impact without the title inflation.
+{{< /book >}}
+
+{{< book title="The Engineering Executive's Primer" author="Will Larson" link="https://amzn.eu/d/2ET5UiD" type="book" >}}
 Solid foundation for VP+ roles. Strategic thinking, org design, board dynamics. Wish I'd read this before my first CTO gig.
 {{< /book >}}
 
@@ -89,23 +74,19 @@ Solid foundation for VP+ roles. Strategic thinking, org design, board dynamics. 
 
 I've tried dozens. These are the ones I actually read every week.
 
-### Tech Leadership
-
-{{< book title="Software Lead Weekly" author="Oren Ellenbogen" link="http://softwareleadweekly.com/" type="newsletter" rating="5" >}}
+{{< book title="Software Lead Weekly" author="Oren Ellenbogen" link="http://softwareleadweekly.com/" type="newsletter" >}}
 Oren Ellenbogen curates five sharp articles weekly on tech and leadership. No fluff, just signal.
 {{< /book >}}
 
-{{< book title="Level Up" author="Pat Kua" link="http://levelup.patkua.com/" type="newsletter" rating="5" >}}
+{{< book title="Level Up" author="Pat Kua" link="http://levelup.patkua.com/" type="newsletter" >}}
 Pat Kua was Chief Scientist when I was at N26. One of the sharpest minds I've worked with. His weekly 15-20 links on leadership, tech, and org design are gold.
 {{< /book >}}
 
-{{< book title="The Weekly Hagakure" author="Paulo Andre" link="https://hagakure.substack.com/" type="newsletter" rating="5" >}}
+{{< book title="The Weekly Hagakure" author="Paulo Andre" link="https://hagakure.substack.com/" type="newsletter" >}}
 Paulo André and I overlapped at HelloFresh. His newsletter has the perfect mix: three articles, two videos, one book rec. Always thought-provoking.
 {{< /book >}}
 
-### Software Engineering
-
-{{< book title="Changelog" author="Changelog Media" link="https://changelog.com/" type="newsletter" rating="4" >}}
+{{< book title="Changelog" author="Changelog Media" link="https://changelog.com/" type="newsletter" >}}
 Weekly pulse on what's happening in engineering. Good for staying current without drowning in noise.
 {{< /book >}}
 
@@ -113,22 +94,18 @@ Weekly pulse on what's happening in engineering. Good for staying current withou
 
 What I listen to while brewing coffee or on long flights.
 
-### Tech Leadership
-
-{{< book title="The Critical Channel" author="Italo Vietro" link="https://www.listennotes.com/podcasts/the-critical-channel-criticalchannelio-UIiaVfJRxrs/" type="podcast" rating="5" >}}
+{{< book title="The Critical Channel" author="Italo Vietro" link="https://www.listennotes.com/podcasts/the-critical-channel-criticalchannelio-UIiaVfJRxrs/" type="podcast" >}}
 My podcast. We talk leadership, culture, and the messy reality of building engineering teams. Real stories, no corporate speak.
 {{< /book >}}
 
-### Software Engineering
-
-{{< book title="The Ladybug Podcast" author="Emma Bostian, Kelly Vaughn, Ali Spittel" link="https://www.listennotes.com/podcasts/ladybug-podcast-emma-wedekind-kelly-vaughn-swCn6DupJQe/" type="podcast" rating="4" >}}
+{{< book title="The Ladybug Podcast" author="Emma Bostian, Kelly Vaughn, Ali Spittel" link="https://www.listennotes.com/podcasts/ladybug-podcast-emma-wedekind-kelly-vaughn-swCn6DupJQe/" type="podcast" >}}
 Fresh perspectives from three women engineers. Shorter episodes, diverse topics. Refreshing take on the industry.
 {{< /book >}}
 
-{{< book title="Kubernetes Podcast" author="Adam Glick, Craig Box" link="https://www.listennotes.com/podcasts/kubernetes-podcast-from-google-adam-glick-0hPZxnL7suS/" type="podcast" rating="4" >}}
+{{< book title="Kubernetes Podcast" author="Adam Glick, Craig Box" link="https://www.listennotes.com/podcasts/kubernetes-podcast-from-google-adam-glick-0hPZxnL7suS/" type="podcast" >}}
 Weekly K8s news and community interviews. Essential if you live in the cloud-native world.
 {{< /book >}}
 
-{{< book title="Go Time" author="Mat Ryer, Johnny Boursiquot, Angelica Hill" link="https://www.listennotes.com/podcasts/go-time/defer-gotime-cC8RWfLohr3/" type="podcast" rating="4" >}}
+{{< book title="Go Time" author="Mat Ryer, Johnny Boursiquot, Angelica Hill" link="https://www.listennotes.com/podcasts/go-time/defer-gotime-cC8RWfLohr3/" type="podcast" >}}
 Weekly Go discussions. Whether you're deep in Go or just curious, solid conversations about the language and ecosystem.
 {{< /book >}}

--- a/content/recommended-reading/index.en.md
+++ b/content/recommended-reading/index.en.md
@@ -26,8 +26,8 @@ The ones I hand over first.
 Read this five years into my career. Changed everything about how I approached readability, testing, and maintenance. Stop writing code for compilers; write it for humans.
 {{< /book >}}
 
-{{< book title="Domain-Driven Design" author="Eric Evans" link="https://amzn.to/32NQx63" type="book" featured="true" >}}
-The book that taught me to speak business language in code. Ubiquitous language and bounded contexts aren't buzzwords—they're how you survive complex domains without losing your mind.
+{{< book title="Implementing Domain-Driven Design" author="Vaughn Vernon" link="https://www.amazon.de/-/en/Implementing-Domain-Driven-Design-Vaughn-Vernon/dp/0321834577" type="book" featured="true" >}}
+The red book. Much nicer and more precise than the blue one, and the one I hand over now. Evans gave us the ideas; Vernon shows you how to actually build with them.
 {{< /book >}}
 
 {{< book title="Grokking Algorithms" author="Aditya Bhargava" link="https://amzn.to/3pvir0o" type="book" featured="true" >}}
@@ -49,6 +49,10 @@ DevOps wrapped in a novel. Sounds cheesy, but it works. Read this when you're st
 ## More Books
 
 Books that changed how I write code, and the ones that helped me not suck at leading people.
+
+{{< book title="Domain-Driven Design" author="Eric Evans" link="https://amzn.to/32NQx63" type="book" >}}
+The blue book, and still where the ideas come from. It taught me to speak business language in code. Ubiquitous language and bounded contexts aren't buzzwords—they're how you survive complex domains without losing your mind.
+{{< /book >}}
 
 {{< book title="Refactoring" author="Martin Fowler" link="https://amzn.to/3lDbNmG" type="book" >}}
 Martin Fowler's catalog of "how to improve code without breaking it." I still reference specific patterns from this book when reviewing PRs.

--- a/content/recommended-reading/index.en.md
+++ b/content/recommended-reading/index.en.md
@@ -7,9 +7,9 @@ draft: false
 ---
 
 
-I've always believed that **knowledge travels faster than code**. Over 17+ years, these books, newsletters, and podcasts have shaped how I think about building systems, leading teams, and growing as an engineering leader.
+I've always believed that **knowledge travels faster than code**. Over the years, these books, newsletters, and podcasts have shaped how I think about building systems, leading teams, and growing as an engineering leader.
 
-This isn't a complete list—just the ones that stuck. The ones I return to. The ones I push into people's hands when they ask, "what should I read?"
+This isn't a complete list, but just the ones that stuck with me. The ones I return to. The ones I push into people's hands when they ask, "what should I read?"
 
 ---
 

--- a/content/recommended-reading/index.pt-br.md
+++ b/content/recommended-reading/index.pt-br.md
@@ -7,9 +7,9 @@ draft: false
 ---
 
 
-Sempre acreditei que **o conhecimento viaja mais rápido que o código**. Ao longo de mais de 17 anos, esses livros, newsletters e podcasts moldaram como penso sobre construir sistemas, liderar times e crescer como líder de engenharia.
+Sempre acreditei que **o conhecimento viaja mais rápido que o código**. Ao longo dos anos, esses livros, newsletters e podcasts moldaram como penso sobre construir sistemas, liderar times e crescer como líder de engenharia.
 
-Esta não é uma lista completa—apenas aqueles que ficaram. Os que eu revisito. Os que eu coloco nas mãos das pessoas quando perguntam "o que devo ler?"
+Esta não é uma lista completa, mas apenas os que ficaram comigo. Os que eu revisito. Os que eu coloco nas mãos das pessoas quando perguntam "o que devo ler?"
 
 ---
 

--- a/content/recommended-reading/index.pt-br.md
+++ b/content/recommended-reading/index.pt-br.md
@@ -26,8 +26,8 @@ Os que eu entrego primeiro.
 Li isso cinco anos depois de começar minha carreira. Mudou tudo sobre como eu abordo legibilidade, testes e manutenção. Pare de escrever código para compiladores; escreva para humanos.
 {{< /book >}}
 
-{{< book title="Domain-Driven Design" author="Eric Evans" link="https://amzn.to/32NQx63" type="book" featured="true" >}}
-O livro que me ensinou a falar a linguagem do negócio em código. Linguagem ubíqua e contextos delimitados não são buzzwords—são como você sobrevive a domínios complexos sem perder a sanidade.
+{{< book title="Implementing Domain-Driven Design" author="Vaughn Vernon" link="https://www.amazon.de/-/en/Implementing-Domain-Driven-Design-Vaughn-Vernon/dp/0321834577" type="book" featured="true" >}}
+O livro vermelho. Bem melhor e mais preciso que o azul, e é o que eu entrego hoje. Evans trouxe as ideias; Vernon mostra como construir com elas.
 {{< /book >}}
 
 {{< book title="Grokking Algorithms" author="Aditya Bhargava" link="https://amzn.to/3pvir0o" type="book" featured="true" >}}
@@ -49,6 +49,10 @@ DevOps embrulhado em romance. Parece cafona, mas funciona. Leia isso quando esti
 ## Mais livros
 
 Livros que mudaram como escrevo código, e os que me ajudaram a não ser ruim liderando pessoas.
+
+{{< book title="Domain-Driven Design" author="Eric Evans" link="https://amzn.to/32NQx63" type="book" >}}
+O livro azul, e ainda é de onde vêm as ideias. Foi ele que me ensinou a falar a linguagem do negócio em código. Linguagem ubíqua e contextos delimitados não são buzzwords—são como você sobrevive a domínios complexos sem perder a sanidade.
+{{< /book >}}
 
 {{< book title="Refactoring" author="Martin Fowler" link="https://amzn.to/3lDbNmG" type="book" >}}
 Catálogo do Martin Fowler de "como melhorar código sem quebrar". Ainda referencio padrões específicos deste livro ao revisar PRs.

--- a/content/recommended-reading/index.pt-br.md
+++ b/content/recommended-reading/index.pt-br.md
@@ -13,75 +13,60 @@ Esta não é uma lista completa—apenas aqueles que ficaram. Os que eu revisito
 
 ---
 
-* [Currently Reading](#currently-reading)
-* [Livros de Engenharia](#livros-de-engenharia)
-* [Livros de Gestão](#livros-de-gestao)
+* [Comece por aqui](#comece-por-aqui)
+* [Mais livros](#mais-livros)
 * [Newsletters](#newsletters)
 * [Podcasts](#podcasts)
 
-## Currently Reading
+## Comece por aqui
 
-{{< book title="[Book Title]" author="[Author Name]" link="https://example.com" type="book" >}}
-[Por que estou lendo isso -- substitua com sua leitura atual.]
-{{< /book >}}
+Os que eu entrego primeiro.
 
-## Livros de Engenharia
-
-Livros que mudaram como escrevo código e penso sobre sistemas.
-
-### Must Read
-
-{{< book title="Clean Code" author="Robert C. Martin" link="https://amzn.to/3f4tfO8" type="book" rating="5" >}}
+{{< book title="Clean Code" author="Robert C. Martin" link="https://amzn.to/3f4tfO8" type="book" featured="true" >}}
 Li isso cinco anos depois de começar minha carreira. Mudou tudo sobre como eu abordo legibilidade, testes e manutenção. Pare de escrever código para compiladores; escreva para humanos.
 {{< /book >}}
 
-{{< book title="Domain-Driven Design" author="Eric Evans" link="https://amzn.to/32NQx63" type="book" rating="5" >}}
+{{< book title="Domain-Driven Design" author="Eric Evans" link="https://amzn.to/32NQx63" type="book" featured="true" >}}
 O livro que me ensinou a falar a linguagem do negócio em código. Linguagem ubíqua e contextos delimitados não são buzzwords—são como você sobrevive a domínios complexos sem perder a sanidade.
 {{< /book >}}
 
-{{< book title="Grokking Algorithms" author="Aditya Bhargava" link="https://amzn.to/3pvir0o" type="book" rating="5" >}}
+{{< book title="Grokking Algorithms" author="Aditya Bhargava" link="https://amzn.to/3pvir0o" type="book" featured="true" >}}
 O livro de algoritmos que não parece lição de casa. Exemplos claros, pedaços digestíveis. Perfeito para refrescar antes de entrevistas ou quando você precisa lembrar por que hash tables existem.
 {{< /book >}}
 
-### Recommended
-
-{{< book title="Refactoring" author="Martin Fowler" link="https://amzn.to/3lDbNmG" type="book" rating="4" >}}
-Catálogo do Martin Fowler de "como melhorar código sem quebrar". Ainda referencio padrões específicos deste livro ao revisar PRs.
-{{< /book >}}
-
-{{< book title="Clean Architecture" author="Robert C. Martin" link="https://amzn.to/3f4tfO8" type="book" rating="4" >}}
-Continuação do Uncle Bob ao Clean Code. Menos sobre código, mais sobre estrutura. Ajuda você a evitar os erros arquiteturais que eu cometi no início da carreira.
-{{< /book >}}
-
-{{< book title="Site Reliability Engineering" author="Betsy Beyer, Chris Jones, Jennifer Petoff, Niall Richard Murphy" link="https://amzn.to/3kzDD1R" type="book" rating="4" >}}
-A bíblia de SRE do Google. Primeira metade vai parecer familiar se você já fez on-call. Lembre-se: o que funciona na escala do Google pode ser exagero para você. Mas os princípios? Sólidos.
-{{< /book >}}
-
-{{< book title="Staff Engineer" author="Will Larson" link="https://amzn.eu/d/cAtTpf3" type="book" rating="4" >}}
-Bateu diferente quando estava navegando entre IC vs gestão. Roteiro prático para ICs seniores que querem impacto sem inflação de título.
-{{< /book >}}
-
-## Livros de Gestão
-
-Os livros que me ajudaram a não ser ruim liderando pessoas.
-
-### Must Read
-
-{{< book title="The Manager's Path" author="Camille Fournier" link="https://amzn.to/3f0FnzM" type="book" rating="5" >}}
+{{< book title="The Manager's Path" author="Camille Fournier" link="https://amzn.to/3f0FnzM" type="book" featured="true" >}}
 Seu roteiro de tech lead a CTO. Camille Fournier acerta em cada estágio. Releio capítulos diferentes dependendo de onde estou. Atualmente marcando a seção de VP.
 {{< /book >}}
 
-{{< book title="An Elegant Puzzle" author="Will Larson" link="https://amzn.to/3kHB3Hb" type="book" rating="5" >}}
+{{< book title="An Elegant Puzzle" author="Will Larson" link="https://amzn.to/3kHB3Hb" type="book" featured="true" >}}
 O guia do Will Larson é o livro mais prático de gestão de engenharia que encontrei. Táticas reais para contratação, dinâmica de time e escalar organizações. Só o apêndice vale o preço—uma mina de ouro de recomendações de papers.
 {{< /book >}}
 
-{{< book title="The Phoenix Project" author="Gene Kim, Kevin Behr, George Spafford" link="https://amzn.to/3kyPsVU" type="book" rating="5" >}}
+{{< book title="The Phoenix Project" author="Gene Kim, Kevin Behr, George Spafford" link="https://amzn.to/3kyPsVU" type="book" featured="true" >}}
 DevOps embrulhado em romance. Parece cafona, mas funciona. Leia isso quando estiver lutando para explicar por que "só entregue mais rápido" não é estratégia.
 {{< /book >}}
 
-### Recommended
+## Mais livros
 
-{{< book title="The Engineering Executive's Primer" author="Will Larson" link="https://amzn.eu/d/2ET5UiD" type="book" rating="4" >}}
+Livros que mudaram como escrevo código, e os que me ajudaram a não ser ruim liderando pessoas.
+
+{{< book title="Refactoring" author="Martin Fowler" link="https://amzn.to/3lDbNmG" type="book" >}}
+Catálogo do Martin Fowler de "como melhorar código sem quebrar". Ainda referencio padrões específicos deste livro ao revisar PRs.
+{{< /book >}}
+
+{{< book title="Clean Architecture" author="Robert C. Martin" link="https://amzn.to/3f4tfO8" type="book" >}}
+Continuação do Uncle Bob ao Clean Code. Menos sobre código, mais sobre estrutura. Ajuda você a evitar os erros arquiteturais que eu cometi no início da carreira.
+{{< /book >}}
+
+{{< book title="Site Reliability Engineering" author="Betsy Beyer, Chris Jones, Jennifer Petoff, Niall Richard Murphy" link="https://amzn.to/3kzDD1R" type="book" >}}
+A bíblia de SRE do Google. Primeira metade vai parecer familiar se você já fez on-call. Lembre-se: o que funciona na escala do Google pode ser exagero para você. Mas os princípios? Sólidos.
+{{< /book >}}
+
+{{< book title="Staff Engineer" author="Will Larson" link="https://amzn.eu/d/cAtTpf3" type="book" >}}
+Bateu diferente quando estava navegando entre IC vs gestão. Roteiro prático para ICs seniores que querem impacto sem inflação de título.
+{{< /book >}}
+
+{{< book title="The Engineering Executive's Primer" author="Will Larson" link="https://amzn.eu/d/2ET5UiD" type="book" >}}
 Base sólida para papéis VP+. Pensamento estratégico, design organizacional, dinâmica de conselho. Queria ter lido isso antes do meu primeiro papel de CTO.
 {{< /book >}}
 
@@ -89,23 +74,19 @@ Base sólida para papéis VP+. Pensamento estratégico, design organizacional, d
 
 Tentei dezenas. Essas são as que eu realmente leio toda semana.
 
-### Liderança Técnica
-
-{{< book title="Software Lead Weekly" author="Oren Ellenbogen" link="http://softwareleadweekly.com/" type="newsletter" rating="5" >}}
+{{< book title="Software Lead Weekly" author="Oren Ellenbogen" link="http://softwareleadweekly.com/" type="newsletter" >}}
 Oren Ellenbogen curada cinco artigos afiados semanalmente sobre tech e liderança. Sem enrolação, só sinal.
 {{< /book >}}
 
-{{< book title="Level Up" author="Pat Kua" link="http://levelup.patkua.com/" type="newsletter" rating="5" >}}
+{{< book title="Level Up" author="Pat Kua" link="http://levelup.patkua.com/" type="newsletter" >}}
 Pat Kua era Chief Scientist quando eu estava na N26. Uma das mentes mais afiadas com quem trabalhei. Seus 15-20 links semanais sobre liderança, tech e design organizacional são ouro.
 {{< /book >}}
 
-{{< book title="The Weekly Hagakure" author="Paulo Andre" link="https://hagakure.substack.com/" type="newsletter" rating="5" >}}
+{{< book title="The Weekly Hagakure" author="Paulo Andre" link="https://hagakure.substack.com/" type="newsletter" >}}
 Paulo André e eu nos cruzamos na HelloFresh. Sua newsletter tem o mix perfeito: três artigos, dois vídeos, uma recomendação de livro. Sempre provocante.
 {{< /book >}}
 
-### Engenharia de Software
-
-{{< book title="Changelog" author="Changelog Media" link="https://changelog.com/" type="newsletter" rating="4" >}}
+{{< book title="Changelog" author="Changelog Media" link="https://changelog.com/" type="newsletter" >}}
 Pulso semanal sobre o que está acontecendo em engenharia. Bom para ficar atualizado sem se afogar em ruído.
 {{< /book >}}
 
@@ -113,22 +94,18 @@ Pulso semanal sobre o que está acontecendo em engenharia. Bom para ficar atuali
 
 O que ouço enquanto faço café ou em voos longos.
 
-### Liderança Técnica
-
-{{< book title="The Critical Channel" author="Italo Vietro" link="https://www.listennotes.com/podcasts/the-critical-channel-criticalchannelio-UIiaVfJRxrs/" type="podcast" rating="5" >}}
+{{< book title="The Critical Channel" author="Italo Vietro" link="https://www.listennotes.com/podcasts/the-critical-channel-criticalchannelio-UIiaVfJRxrs/" type="podcast" >}}
 Meu podcast. Falamos sobre liderança, cultura e a realidade bagunçada de construir times de engenharia. Histórias reais, sem papo corporativo.
 {{< /book >}}
 
-### Engenharia de Software
-
-{{< book title="The Ladybug Podcast" author="Emma Bostian, Kelly Vaughn, Ali Spittel" link="https://www.listennotes.com/podcasts/ladybug-podcast-emma-wedekind-kelly-vaughn-swCn6DupJQe/" type="podcast" rating="4" >}}
+{{< book title="The Ladybug Podcast" author="Emma Bostian, Kelly Vaughn, Ali Spittel" link="https://www.listennotes.com/podcasts/ladybug-podcast-emma-wedekind-kelly-vaughn-swCn6DupJQe/" type="podcast" >}}
 Perspectivas frescas de três mulheres engenheiras. Episódios mais curtos, tópicos diversos. Visão refrescante da indústria.
 {{< /book >}}
 
-{{< book title="Kubernetes Podcast" author="Adam Glick, Craig Box" link="https://www.listennotes.com/podcasts/kubernetes-podcast-from-google-adam-glick-0hPZxnL7suS/" type="podcast" rating="4" >}}
+{{< book title="Kubernetes Podcast" author="Adam Glick, Craig Box" link="https://www.listennotes.com/podcasts/kubernetes-podcast-from-google-adam-glick-0hPZxnL7suS/" type="podcast" >}}
 Notícias semanais de K8s e entrevistas da comunidade. Essencial se você vive no mundo cloud-native.
 {{< /book >}}
 
-{{< book title="Go Time" author="Mat Ryer, Johnny Boursiquot, Angelica Hill" link="https://www.listennotes.com/podcasts/go-time/defer-gotime-cC8RWfLohr3/" type="podcast" rating="4" >}}
+{{< book title="Go Time" author="Mat Ryer, Johnny Boursiquot, Angelica Hill" link="https://www.listennotes.com/podcasts/go-time/defer-gotime-cC8RWfLohr3/" type="podcast" >}}
 Discussões semanais sobre Go. Seja você profundo em Go ou apenas curioso, conversas sólidas sobre a linguagem e ecossistema.
 {{< /book >}}

--- a/layouts/_default/section.html
+++ b/layouts/_default/section.html
@@ -1,0 +1,64 @@
+{{- define "title" }}
+    {{- .Title | default (T .Section) | default .Section }} - {{ .Site.Title -}}
+{{- end -}}
+
+{{- define "content" -}}
+    {{- /*
+        Overrides the theme's section template.
+
+        The theme rendered a bare list: a right-aligned "All Posts" heading, then
+        year groups of link + numeric date and nothing else. Every post already
+        carries a `description` in its front matter and none of it was shown, so
+        the page had no substance next to the reading list and speaking pages.
+
+        Three changes:
+          - the section's own title and intro come from content/posts/_index.*.md,
+            so the page opens with context the way the others do
+          - each entry shows its description
+          - headings run h1 -> h2 -> h3 with no gaps. The theme used h2 for the
+            page title and h3 for year groups, leaving no h1 on the page at all.
+    */ -}}
+    <div class="page archive">
+        <h1 class="single-title">
+            {{- .Title | default (T .Section) | default .Section | emojify -}}
+        </h1>
+
+        {{- with .Content -}}
+            <div class="archive-intro">{{ . }}</div>
+        {{- end -}}
+
+        {{- if .Pages -}}
+            {{- $pages := .Pages.GroupByDate "2006" -}}
+            {{- with .Site.Params.section.paginate | default .Site.Params.paginate -}}
+                {{- $pages = $.Paginate $pages . -}}
+            {{- else -}}
+                {{- $pages = .Paginate $pages -}}
+            {{- end -}}
+            {{- range $pages.PageGroups -}}
+                <h2 class="group-title">{{ .Key }}</h2>
+                {{- range .Pages -}}
+                    <article class="archive-item">
+                        <div class="archive-item__header">
+                            <h3 class="archive-item__title">
+                                <a href="{{ .RelPermalink }}">{{ .Title | emojify }}</a>
+                            </h3>
+                            <span class="archive-item__date">
+                                {{- $.Site.Params.section.dateFormat | default "January 2" | .Date.Format -}}
+                            </span>
+                        </div>
+                        {{- /*
+                            markdownify because at least one description contains
+                            a markdown link, which rendered as raw [text](url)
+                            syntax on the page. Descriptions still reach meta tags
+                            unprocessed, which is where plain text belongs.
+                        */ -}}
+                        {{- with .Description -}}
+                            <div class="archive-item__desc">{{ . | emojify | markdownify }}</div>
+                        {{- end -}}
+                    </article>
+                {{- end -}}
+            {{- end -}}
+            {{- partial "paginator.html" . -}}
+        {{- end -}}
+    </div>
+{{- end -}}

--- a/layouts/shortcodes/book.html
+++ b/layouts/shortcodes/book.html
@@ -1,21 +1,28 @@
 {{- /* layouts/shortcodes/book.html */ -}}
-{{- /* Parameters: title (required), author (required), link (required), type (required), rating (Phase 3) */ -}}
-{{- $title  := .Get "title" -}}
-{{- $author := .Get "author" -}}
-{{- $link   := .Get "link" -}}
-{{- $type   := .Get "type" | default "book" -}}
-{{- $rating := .Get "rating" | default "" -}}
-{{- $inner  := trim .Inner "\n" | .Page.RenderString -}}
-<div class="book-entry book-entry--{{ $type }}">
+{{- /*
+    Parameters: title, author, link (all required), type (book|newsletter|podcast),
+    featured (optional).
+
+    No rating parameter any more. There was one, and every entry scored 4 or 5 out
+    of 5 -- ten fives and nine fours. A scale whose values all sit in the top 40%
+    is decoration rather than information, and it was spending 86 amber glyphs to
+    say nothing. Being on this list is the recommendation; the prose carries how
+    strongly.
+
+    The title is an h3, not an h4. Sections here have no subheadings, so an h4
+    skipped a level and left screen readers with a broken outline.
+*/ -}}
+{{- $title    := .Get "title" -}}
+{{- $author   := .Get "author" -}}
+{{- $link     := .Get "link" -}}
+{{- $type     := .Get "type" | default "book" -}}
+{{- $featured := .Get "featured" -}}
+{{- $inner    := trim .Inner "\n" | .Page.RenderString -}}
+<div class="book-entry book-entry--{{ $type }}{{ if $featured }} book-entry--featured{{ end }}">
     <div class="book-entry__header">
-        <h4 class="book-entry__title">
+        <h3 class="book-entry__title">
             <a href="{{ $link }}" target="_blank" rel="noopener noreferrer">{{ $title }}</a>
-            {{- if $rating -}}
-            <span class="book-entry__rating" aria-label="{{ $rating }} out of 5 stars">
-              {{- range (seq (int $rating)) -}}<i class="fas fa-star"></i>{{- end -}}
-            </span>
-            {{- end -}}
-        </h4>
+        </h3>
         <span class="book-entry__author">{{ $author }}</span>
     </div>
     <div class="book-entry__description">

--- a/scripts/check-build.sh
+++ b/scripts/check-build.sh
@@ -76,6 +76,7 @@ EN_HOME="$PUBLIC/index.html"
 PT_HOME="$PUBLIC/pt-br/index.html"
 EN_SPEAKING="$PUBLIC/speaking/index.html"
 PT_SPEAKING="$PUBLIC/pt-br/palestras/index.html"
+EN_ARCHIVE="$PUBLIC/posts/index.html"
 EN_READING="$PUBLIC/recommended-reading/index.html"
 PT_READING="$PUBLIC/pt-br/leituras-recomendadas/index.html"
 # The stylesheet name carries a content fingerprint, so resolve it rather than
@@ -121,6 +122,14 @@ contains "$PT_HOME" '/pt-br/posts/' 'pt-br homepage links to the writing archive
 contains "$EN_HOME" '>Writing<' 'Writing appears in the en nav'
 contains "$PT_HOME" '>Artigos<' 'Artigos appears in the pt-br nav'
 contains "$EN_HOME" 'home-route__name' 'the homepage route list renders'
+contains "$EN_HOME" '>Reading<' 'nav uses the short parallel label, not the sentence fragment'
+
+# The archive page showed link-and-date rows and nothing else, while every post
+# already carried a description in front matter. These guard the substance.
+echo 'Writing archive has substance'
+contains "$EN_ARCHIVE" 'archive-item__desc' 'archive entries show their descriptions'
+contains "$EN_ARCHIVE" '>Writing<' 'archive has its own title, not the generic "All Posts"'
+absent_from "$EN_ARCHIVE" '](http' 'no raw markdown link syntax leaks into a description'
 
 echo 'Reading list'
 nowhere '[Book Title]' 'the placeholder entry appears nowhere'

--- a/scripts/check-build.sh
+++ b/scripts/check-build.sh
@@ -76,6 +76,8 @@ EN_HOME="$PUBLIC/index.html"
 PT_HOME="$PUBLIC/pt-br/index.html"
 EN_SPEAKING="$PUBLIC/speaking/index.html"
 PT_SPEAKING="$PUBLIC/pt-br/palestras/index.html"
+EN_READING="$PUBLIC/recommended-reading/index.html"
+PT_READING="$PUBLIC/pt-br/leituras-recomendadas/index.html"
 # The stylesheet name carries a content fingerprint, so resolve it rather than
 # hardcoding a hash that changes on every style edit.
 CSS=$(find "$PUBLIC/css" -maxdepth 1 -name 'style.min.*.css' ! -name '*.map' -print -quit 2>/dev/null)
@@ -105,6 +107,18 @@ absent_from "$CSS" '#ef3982' 'theme default hover pink is gone from the styleshe
 # to these two files by name. If Hugo stopped emitting either, that route would
 # resolve to nothing and the failure would only surface as a broken 404 page in
 # production -- the least likely place anyone looks.
+# The reading list was rebuilt around a featured set. These guard the three things
+# that would silently undo it: the placeholder coming back, ratings returning, and
+# entry titles reverting to h4 (which skipped a heading level, because sections
+# here have no subheadings).
+echo 'Reading list'
+nowhere '[Book Title]' 'the placeholder entry appears nowhere'
+absent_from "$EN_READING" 'fa-star' 'no star ratings remain'
+absent_from "$EN_READING" '<h4' 'entry titles are h3, leaving no gap in the heading outline'
+contains "$EN_READING" 'Start Here' 'en has the featured section'
+contains "$PT_READING" 'Comece por aqui' 'pt-br has the featured section, translated'
+nowhere 'Must Read' 'the tier subheadings are gone from both languages'
+
 echo 'Error pages'
 exists "$PUBLIC/404.html" 'en 404 page exists for the catch-all route'
 exists "$PUBLIC/pt-br/404.html" 'pt-br 404 page exists for the localized route'

--- a/scripts/check-build.sh
+++ b/scripts/check-build.sh
@@ -111,6 +111,17 @@ absent_from "$CSS" '#ef3982' 'theme default hover pink is gone from the styleshe
 # that would silently undo it: the placeholder coming back, ratings returning, and
 # entry titles reverting to h4 (which skipped a heading level, because sections
 # here have no subheadings).
+# The highest-value guard on the site. Six published posts sat live at /posts/
+# with nothing in the nav or on the homepage linking to them, so a visitor
+# arriving at the domain could not reach any of them. Nothing about that failure
+# was visible: the posts returned 200, they were indexed, and RSS carried them.
+echo 'Writing is reachable'
+contains "$EN_HOME" '/posts/' 'en homepage links to the writing archive'
+contains "$PT_HOME" '/pt-br/posts/' 'pt-br homepage links to the writing archive'
+contains "$EN_HOME" '>Writing<' 'Writing appears in the en nav'
+contains "$PT_HOME" '>Artigos<' 'Artigos appears in the pt-br nav'
+contains "$EN_HOME" 'home-route__name' 'the homepage route list renders'
+
 echo 'Reading list'
 nowhere '[Book Title]' 'the placeholder entry appears nowhere'
 absent_from "$EN_READING" 'fa-star' 'no star ratings remain'


### PR DESCRIPTION
## Description

The reading list read as chaotic because **everything on it had the same weight**. Twenty entries styled identically, plus 86 amber stars, an amber `#` on every heading, an amber nav strip and amber titles — four unrelated jobs for one colour, so nothing looked more important than anything else.

Diagnosed from the page's own data rather than taste:

| Finding | Evidence |
| --- | --- |
| Ratings carried no signal | 10 entries rated 5, 9 rated 4, 1 unrated. **86 amber glyphs**, near-zero information |
| More structure than content | **13 headings for 20 entries**. Four subsections held exactly one item |
| Judgment encoded twice | `Must Read`/`Recommended` subheadings *and* star ratings, saying the same thing |
| A live placeholder | `[Book Title]` / `[Author Name]`, on a page shared with colleagues |
| Contrast failure | nine uses of the theme's secondary colour at **2.33:1 light / 2.18:1 dark** |

## Changes

**Ratings removed.** Being on the list is the recommendation; the prose says how strongly.

**13 headings → 4.** `Must Read`/`Recommended` gone. Six entries move to **Start Here** — the set already marked must-read — with a larger title, author on its own line, and the description at full reading size, grouped by a quiet accent edge.

That left Engineering with 4 and Management with 1, recreating the orphan problem, so those merge into **More Books**. Newsletters and Podcasts flatten the same way.

**Every description survives.** Total prose is ~440 words; volume was never the problem, undifferentiated hierarchy was. Compact entries put title and author on one line with the description beneath in smaller type.

**Amber has one job now** — entry titles, which are the links, and hover states. Section headings, nav and metadata are quiet.

## Fixes found along the way

- **The contrast failure I missed.** When I fixed this same defect in `_speaking.scss` and `_custom.scss` earlier, I did not fix `_reading-list.scss`. Nine uses remained at 2.33:1 / 2.18:1 — which is exactly why the tier labels and author names looked washed out rather than merely subtle. Now 7.63:1 and 5.69:1.
- **`h2 → h4` heading skip closed.** Entry titles are `h3`; sections have no subheadings, so `h4` skipped a level and left screen readers a broken outline. Sequence is now `h1 → h2 → h3` with no gaps.
- **Title no longer right-aligned.** Needed `.special .single-title` to match the theme's specificity — a bare `.single-title` rule loses despite being declared later. Blog posts are unaffected; they were never `.special`.
- **The injected `#` heading mark is hidden.** Theme decoration that read as markdown which failed to render.
- **No separator glyph between title and author.** A `·` orphans itself at the start of the next line when a long author list wraps — "Site Reliability Engineering" and its four authors demonstrated it.
- **pt-br no longer mixes languages.** It had `Currently Reading`, `Must Read` and `Recommended` in English sitting inside Portuguese copy.
- **`text-wrap: balance`** on headings.

## Assertions: 33 → 39

Guarding the parts that would silently revert: the placeholder returning, ratings returning, titles reverting to `h4`, the featured section disappearing in either language, and the tier subheadings coming back.

## Reviewed

Rendered and inspected at 1000px and mobile width. The `[Book Title]` placeholder is deleted rather than filled — tell me what you're actually reading and I'll add a Currently Reading section back.

## Copy for your review

Two lines are new rather than yours, both spliced from sentences already on the page:

- **Start Here** → "The ones I hand over first."
- **More Books** → "Books that changed how I write code, and the ones that helped me not suck at leading people."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update: homepage routing and layout

Researched against two references the author named or that match his shape: **yegge.ai** and **macwright.com**. What they share is not visual — **both homepages route to the work rather than lead with biography.** yegge routes to four content areas via showcase cards; macwright routes to seven via nav plus curated recent items, with no photo at all. Both are minimal in decoration and maximal in routing.

### The finding that mattered

**Six published posts were unreachable.**

| | |
| --- | --- |
| Posts live and returning 200 | 6 — `/do-job-titles-matter/`, `/cto-reading-list-1..3/`, `/5-ways-to-keep-coding.../`, `/how-do-we-manage.../` |
| Header nav | 2 items, neither of them Writing |
| Homepage internal links | `/recommended-reading/`, `/speaking/`, `/index.xml`, the logo |

Google could find the writing. RSS carried it. A human who typed the domain could not reach any of it. Nothing about the failure was visible — every post returned 200, and `/posts/` rendered a correct archive grouped by year.

### Changes

- **Writing added to the nav** in both languages (`Writing` / `Artigos` → `/posts/`).
- **A three-row route list on the homepage** — Writing, What I'm Reading, Speaking — each with one line saying what is there. Rows, not cards: at three items a box around text earns nothing a rule and some space do not.
- **One alignment axis.** The page stacked a centred avatar/tagline/social block above left-aligned prose. Now left throughout.
- **Two cancelling hacks removed.** The theme pushes the profile down `translateY(16vh)` to vertically centre it — ~210px of dead space under the header, varying with viewport height — and the content below carried a matching `13rem` top margin to compensate. Both gone.
- **Avatar to 88px**, wrapper padding zeroed. It had been sitting 8px right of the text column, so nothing lined up; portrait, subtitle, prose and routes now share one left edge.
- **Social icons quieted.** They were the first interactive elements a visitor met and the least interesting thing on the page. yegge.ai omits them outright; these stay, muted.

### Assertions: 39 → 44

Five guard the dead-end from returning: both homepages link to the archive, Writing/Artigos appear in both navs, and the route list renders. This is the highest-value guard on the site, because the failure it catches is completely invisible.

### Two things for you, not code

- **Your newest post is March 2021.** Routing to Writing is still right — six findable posts beat six unreachable ones — but the homepage now points at five-year-old work.
- **The tagline is empty on first paint.** `typeit = true` animates "The hardest problems aren't technical." character by character, so it is a bare cursor until the animation runs, and absent in any screenshot or preview capture. Setting `typeit = false` would show it immediately and drop a 12K dependency. Left alone because it is a deliberate choice of yours.
